### PR TITLE
Migrate from sed extended regular expressions

### DIFF
--- a/pants
+++ b/pants
@@ -56,7 +56,7 @@ function bootstrap_pants {
   pants_requirement="pantsbuild.pants"
   pants_version=$(
     grep -E "^[[:space:]]*pants_version" pants.ini 2>/dev/null | \
-      sed -E 's|^[[:space:]]*pants_version[:=][[:space:]]*([^[:space:]]+)|\1|'
+      cut -f2 -d: | tr -d ""
   )
   if [[ -n "${pants_version}" ]]
   then


### PR DESCRIPTION
GNU sed and BSD sed are only recently converged when it comes to supporting -E.

Older versions of GNU sed use -r to use extended regular expressions.
