### PR TITLE
Upgrade default virtualenv version

### DIFF
--- a/pants
+++ b/pants
@@ -16,7 +16,7 @@ PYTHON=${PYTHON:-$(which python2.7)}
 PANTS_HOME="${PANTS_HOME:-${HOME}/.cache/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
-VENV_VERSION=13.1.0
+VENV_VERSION=15.0.0
 
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz


### PR DESCRIPTION
Upgrade default virtualenv version to 15.0.0 in the setup script.

As far as I can tell, the only breaking change is virtualenv dropping support for Python 3.2 in 14.0.0.

This resolves warning messages about using older versions of pip, and also fixes some edge cases where pip < 8 doesn't install certain packages.
