### PR TITLE
Bump setuptools requirement to align with 1.3.0.dev3.

### DIFF
--- a/pants
+++ b/pants
@@ -26,7 +26,7 @@ VENV_VERSION=15.0.2
 # known to be ingestable by both pants and pex. See:
 #   https://github.com/pantsbuild/pants/issues/3948
 #   https://github.com/pantsbuild/setup/issues/14
-SETUPTOOLS_REQUIREMENT="setuptools>=5.7,<31.0"
+SETUPTOOLS_REQUIREMENT="setuptools>=5.4.1,<31.0"
 
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz

--- a/pants
+++ b/pants
@@ -26,7 +26,7 @@ VENV_VERSION=15.0.2
 # known to be ingestable by both pants and pex. See:
 #   https://github.com/pantsbuild/pants/issues/3948
 #   https://github.com/pantsbuild/setup/issues/14
-SETUPTOOLS_REQUIREMENT="setuptools>=5.4.1,<20.11"
+SETUPTOOLS_REQUIREMENT="setuptools>=5.7,<31.0"
 
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz


### PR DESCRIPTION
```
[illuminati my_test_project]$ grep ^SETUPTOOLS pants
SETUPTOOLS_REQUIREMENT="setuptools>=5.4.1,<31.0"
```

```
[illuminati my_test_project]$ rm -rf ~/.cache ~/.pants.d ./.pants.d
[illuminati my_test_project]$ grep pants_version pants.ini
pants_version: 1.0.0
[illuminati my_test_project]$ ./pants help >/dev/null 2>&1; echo $?
0
```

```
[illuminati my_test_project]$ rm -rf ~/.cache ~/.pants.d ./.pants.d
[illuminati my_test_project]$ grep pants_version pants.ini
pants_version: 1.2.0
[illuminati my_test_project]$ ./pants help >/dev/null 2>&1; echo $?
0
```

```
[illuminati my_test_project]$ rm -rf ~/.cache ~/.pants.d ./.pants.d
[illuminati my_test_project]$ grep pants_version pants.ini
pants_version: 1.3.0.dev3
[illuminati my_test_project]$ ./pants help >/dev/null 2>&1; echo $?
0
```
