### PR TITLE
Force setuptools to a known good version.

### DIFF
--- a/pants
+++ b/pants
@@ -20,13 +20,15 @@ PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
 VENV_VERSION=15.0.2
 
-# This requirement is installed alongside pantsbuild.pants to hack around
+# This requirement is installed before pantsbuild.pants to hack around
 # interpreters that have newer setuptools already installed, effectively
-# re-installing an older setuptools and pinning low to the version range
-# known to be ingestable by both pants and pex. See:
+# re-installing an older setuptools and pinning low to a version known to be 
+# ingestable by both pants and pex for all reasonable versions of pants.
+# See:
 #   https://github.com/pantsbuild/pants/issues/3948
 #   https://github.com/pantsbuild/setup/issues/14
-SETUPTOOLS_REQUIREMENT="setuptools>=5.4.1,<31.0"
+#   https://github.com/pantsbuild/setup/issues/19
+SETUPTOOLS_REQUIREMENT="setuptools==5.4.1"
 
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz
@@ -78,12 +80,18 @@ function bootstrap_pants {
   if [[ ! -d "${PANTS_BOOTSTRAP}/${pants_version}" ]]
   then
     (
+      # NB: We setup the virtualenv with no setuptools to ensure our
+      # ${SETUPTOOLS_REQUIREMENT} wins.
       venv_path="$(bootstrap_venv)" && \
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
-      "${PYTHON}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install" && \
+      "${PYTHON}" "${venv_path}/virtualenv.py" --no-setuptools --no-download \
+        "${staging_dir}/install" && \
       "${staging_dir}/install/bin/python" \
         "${staging_dir}/install/bin/pip" install \
-          "${SETUPTOOLS_REQUIREMENT}" "${pants_requirement}" && \
+          "${SETUPTOOLS_REQUIREMENT}" && \
+      "${staging_dir}/install/bin/python" \
+        "${staging_dir}/install/bin/pip" install \
+          "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}" && \
       mv "${staging_dir}/${pants_version}" "${PANTS_BOOTSTRAP}/${pants_version}"
     ) 1>&2


### PR DESCRIPTION
We now:
+ Setup a virtualenv with no system setuptools.
+ Install a known good fixed version of setuptools in the pants venv.
+ Finally install pants.

Closes #19 