### PR TITLE
Improve pants script robustness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.pants.d/
+/.pants.workdir.file_lock
+/.pids/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,38 +7,36 @@ branches:
   only:
     - gh-pages
 
-script: "./pants --version && ./pants list ::"
+script:
+  - "./pants --version"
+  - "./pants list ::"
+  - "PANTS_ENABLE_PANTSD=True ./pants --version"
+  - "PANTS_ENABLE_PANTSD=True ./pants list ::"
 
 matrix:
   include:
-    - os: osx
-      osx_image: xcode7.3
+    - name: "OSX 10.11 - El Capitan"
+      os: osx
+      osx_image: xcode8.0
       language: generic
-      env:
-        - OS=10.11
 
-    - os: osx
-      osx_image: xcode8.3.3
+    - name: "OSX 10.12 - Sierra"
+      os: osx
+      osx_image: xcode9.2
       language: generic
-      env:
-        - OS=10.12
 
-    - os: osx
-      osx_image: xcode9.1
+    - name: "OSX 10.13 - High Sierra"
+      os: osx
+      osx_image: xcode9.4
       language: generic
-      env:
-        - OS=10.12
- 
-    - os: linux
+
+    - name: "Ubuntu 12.04 - Precise"
+      os: linux
       dist: precise
       sudo: required
-      env:
-        - OS=ubuntu/precise
 
-    - os: linux
+    - name: "Ubuntu 14.04 - Trusty"
+      os: linux
       dist: trusty
       sudo: false
-      env:
-        - OS=ubuntu/trusty
-
 

--- a/pants
+++ b/pants
@@ -11,14 +11,14 @@
 # You can learn more here: https://pantsbuild.github.io/setup
 # ====================================================================
 
-set -e
+set -eou pipefail
 
 PYTHON=${PYTHON:-$(which python2.7)}
 
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
-VENV_VERSION=${VENV_VERSION:-15.2.0}
+VENV_VERSION=${VENV_VERSION:-16.0.0}
 
 # This requirement is installed before pantsbuild.pants to hack around
 # interpreters that have newer setuptools already installed, effectively
@@ -52,12 +52,12 @@ function bootstrap_venv {
   if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]
   then
     (
-      mkdir -p "${PANTS_BOOTSTRAP}" && \
-      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
-      cd "${staging_dir}" && \
-      curl -LO https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL} && \
-      tar -xzf ${VENV_TARBALL} && \
-      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest" && \
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}
+      tar -xzf ${VENV_TARBALL}
+      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest"
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
     ) 1>&2
   fi
@@ -82,21 +82,29 @@ function bootstrap_pants {
     (
       # NB: We setup the virtualenv with no setuptools to ensure our
       # ${SETUPTOOLS_REQUIREMENT} wins.
-      venv_path="$(bootstrap_venv)" && \
-      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
+      venv_path="$(bootstrap_venv)"
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       "${PYTHON}" "${venv_path}/virtualenv.py" --no-setuptools --no-download \
-        "${staging_dir}/install" && \
-      "${staging_dir}/install/bin/python" \
-        "${staging_dir}/install/bin/pip" install \
-          "${SETUPTOOLS_REQUIREMENT}" && \
-      "${staging_dir}/install/bin/python" \
-        "${staging_dir}/install/bin/pip" install \
-          "${pants_requirement}" && \
-      ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}" && \
+        "${staging_dir}/install"
+      "${staging_dir}/install/bin/pip" install -U pip
+      "${staging_dir}/install/bin/pip" install "${SETUPTOOLS_REQUIREMENT}"
+      "${staging_dir}/install/bin/pip" install "${pants_requirement}"
+      ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}"
       mv "${staging_dir}/${pants_version}" "${PANTS_BOOTSTRAP}/${pants_version}"
     ) 1>&2
   fi
   echo "${PANTS_BOOTSTRAP}/${pants_version}"
 }
-pants_dir=$(bootstrap_pants) && \
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd -P)"
+pants_dir=$(bootstrap_pants)
+
+
+# We set the env var no_proxy to '*', to work around an issue with urllib using non
+# async-signal-safe syscalls after we fork a process that has already spawned threads.
+#
+# See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
+export no_proxy=*
+
 exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.9.0.dev0
+pants_version: 1.10.0.dev2
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',


### PR DESCRIPTION
Handle an issue running pantsd under OSX High Sierra and add a CI setup
to stress this case.

Upgrade virtualenv and pip to latest.

Allow the pants script to be run from a directory other than the pants
script parent dir.

Fixes #10