### PR TITLE
Test Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,8 @@ matrix:
       dist: trusty
       sudo: false
 
+    - name: "Ubuntu 16.04 - Xenial"
+      os: linux
+      dist: xenial
+      sudo: required
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,5 @@ matrix:
     - name: "Ubuntu 16.04 - Xenial"
       os: linux
       dist: xenial
-      sudo: required
+      sudo: false
 


### PR DESCRIPTION
Travis added Xenial back in November. See https://blog.travis-ci.com/2018-11-08-xenial-release.

Adding this test results in better coverage.