### PR TITLE
Add ci.py helper script to allow parametrizing the pants_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
       <<: *linux_setup
       dist: trusty
       before_install:
-        # NB: Trusty image comes with Python 3.4 installed via Pyenv, but we require 3.6+.
+        # NB: Trusty image comes with system Python 3.4, but we require 3.6+.
         # Use pyenv global to ensure we use 2.7 and 3.6, not 3.4.
         - pyenv global 2.7.14 3.6.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ branches:
     - gh-pages
 
 script:
-  - "./pants --version"
-  - "./pants list ::"
-  - "PANTS_ENABLE_PANTSD=True ./pants --version"
-  - "PANTS_ENABLE_PANTSD=True ./pants list ::"
+  - ci.py --pants-version unspecified --python-version unspecified
+  - ci.py --pants-version unspecified --python-version 2.7
+  - ci.py --pants-version unspecified --python-version 3.6
+  - ci.py --pants-version pants.ini --python-version unspecified
+  - ci.py --pants-version pants.ini --python-version 2.7
+  - ci.py --pants-version pants.ini --python-version 3.6
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ branches:
     - gh-pages
 
 script:
-  - ci.py --pants-version unspecified --python-version unspecified
-  - ci.py --pants-version unspecified --python-version 2.7
-  - ci.py --pants-version unspecified --python-version 3.6
-  - ci.py --pants-version pants.ini --python-version unspecified
-  - ci.py --pants-version pants.ini --python-version 2.7
-  - ci.py --pants-version pants.ini --python-version 3.6
+  - ci.py --pants-version unspecified
+  - ci.py --pants-version pants.ini
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ osx_setup: &osx_setup
       packages:
         - openssl
   env:
-    - &env_pyenv >
+    - >
       PYENV_ROOT="${HOME}/.pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
     - >
@@ -26,7 +26,7 @@ osx_setup: &osx_setup
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - &pyenv_install_py36 >
+    - >
       git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
       && ${PYENV_ROOT}/bin/pyenv install 3.6.8
       && ${PYENV_ROOT}/bin/pyenv global 3.6.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ branches:
     - gh-pages
 
 script:
-  - ci.py --pants-version unspecified
-  - ci.py --pants-version pants.ini
+  - ./ci.py --pants-version unspecified
+  - ./ci.py --pants-version pants.ini
 
 osx_setup: &osx_setup
   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
+      before_install:
+        - echo $PATH
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-language: python
-python: "2.7.13"
-
 # Needed to enable Travis CI for gh-pages branches, see:
 #   https://github.com/travis-ci/travis-core/pull/137
 branches:
@@ -11,30 +8,56 @@ script:
   - ci.py --pants-version unspecified
   - ci.py --pants-version pants.ini
 
+osx_setup: &osx_setup
+  os: osx
+  language: generic
+  addons:
+    brew:
+      packages:
+        - openssl
+  env:
+    - &env_pyenv >
+      PYENV_ROOT="${HOME}/.pyenv"
+      PATH="${PYENV_ROOT}/shims:${PATH}"
+    - >
+      # These flags are necessary to get OpenSSL working. See
+      # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+  before_install:
+    - &pyenv_install_py36 >
+      git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
+      && ${PYENV_ROOT}/bin/pyenv install 3.6.8
+      && ${PYENV_ROOT}/bin/pyenv global 3.6.8
+
+linux_setup: &linux_setup
+  os: linux
+  language: python
+  python:
+    - "2.7"
+    - "3.6"
+  sudo: false
+
 matrix:
   include:
     - name: "OSX 10.11 - El Capitan"
-      os: osx
+      <<: *osx_setup
       osx_image: xcode8.0
-      language: generic
 
     - name: "OSX 10.12 - Sierra"
-      os: osx
+      <<: *osx_setup
       osx_image: xcode9.2
-      language: generic
 
     - name: "OSX 10.13 - High Sierra"
-      os: osx
+      <<: *osx_setup
       osx_image: xcode9.4
-      language: generic
 
     - name: "Ubuntu 12.04 - Precise"
-      os: linux
+      <<: *linux_setup
       dist: precise
       sudo: required
 
     - name: "Ubuntu 14.04 - Trusty"
-      os: linux
+      <<: *linux_setup
       dist: trusty
-      sudo: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ branches:
   only:
     - gh-pages
 
+# NB: Python versions cannot be specified globally because they will be parsed by Travis
+# as a desired build matrix, i.e. it will start a job for Py27 and a job for Py37, rather than
+# ensuring each shard has both versions like we actually are requesting. So, we must
+# enumerate the versions in osx_setpu and linux_setup.
 language: python
-python:
-  - "2.7"
-  - "3.6"
 
 script:
   - ./ci.py --pants-version unspecified
@@ -15,10 +16,16 @@ script:
 
 osx_setup: &osx_setup
   os: osx
+  python:
+    - "2.7"
+    - "3.6"
 
 linux_setup: &linux_setup
   os: linux
   sudo: false
+  python:
+    - "2.7"
+    - "3.6"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,11 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
-      env:
-        # NB: Trusty image comes with Python 3.4 installed, but we require 3.6+.
-        # Force 3.6 to the front of the PATH so it gets resolved by ci.py correctly.
-        - PATH="/opt/pyenv/shims/python3.6:${PATH}"
+      before_install:
+        # NB: Trusty image comes with Python 3.4 installed via Pyenv, but we require 3.6+.
+        # Use pyenv global to ensure we use 2.7 and 3.6, not 3.4.
+        - pyenv versions
+        - pyenv global system 3.6.8
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,7 @@ matrix:
       before_install:
         # NB: Trusty image comes with Python 3.4 installed via Pyenv, but we require 3.6+.
         # Use pyenv global to ensure we use 2.7 and 3.6, not 3.4.
-        - pyenv versions
-        - pyenv global system 3.6.8
+        - pyenv global 2.7.14 3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,37 @@ branches:
   only:
     - gh-pages
 
-# NB: Python versions cannot be specified globally because they will be parsed by Travis
-# as a desired build matrix, i.e. it will start a job for Py27 and a job for Py37, rather than
-# ensuring each shard has both versions like we actually are requesting. So, we must
-# enumerate the versions in osx_setpu and linux_setup.
-language: python
-
 script:
   - ./ci.py --pants-version unspecified
   - ./ci.py --pants-version pants.ini
 
 osx_setup: &osx_setup
   os: osx
-  python:
-    - "2.7"
-    - "3.6"
+  language: generic
+  addons:
+    brew:
+      packages:
+        - openssl
+  env:
+    - >
+      PYENV_ROOT="${HOME}/.pyenv"
+      PATH="${PYENV_ROOT}/shims:${PATH}"
+    - >
+      # These flags are necessary to get OpenSSL working. See
+      # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+  before_install:
+    - >
+      git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
+      && ${PYENV_ROOT}/bin/pyenv install 3.6.8
+      && ${PYENV_ROOT}/bin/pyenv global 3.6.8
 
 linux_setup: &linux_setup
   os: linux
   sudo: false
+  language: python
   python:
     - "2.7"
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,39 +4,20 @@ branches:
   only:
     - gh-pages
 
+language: python
+python:
+  - "2.7"
+  - "3.6"
+
 script:
   - ./ci.py --pants-version unspecified
   - ./ci.py --pants-version pants.ini
 
 osx_setup: &osx_setup
   os: osx
-  language: generic
-  addons:
-    brew:
-      packages:
-        - openssl
-  env:
-    - >
-      PYENV_ROOT="${HOME}/.pyenv"
-      PATH="${PYENV_ROOT}/shims:${PATH}"
-    - >
-      # These flags are necessary to get OpenSSL working. See
-      # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
-      PATH="/usr/local/opt/openssl/bin:$PATH"
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CPPFLAGS="-I/usr/local/opt/openssl/include"
-  before_install:
-    - >
-      git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
-      && ${PYENV_ROOT}/bin/pyenv install 3.6.8
-      && ${PYENV_ROOT}/bin/pyenv global 3.6.8
 
 linux_setup: &linux_setup
   os: linux
-  language: python
-  python:
-    - "2.7"
-    - "3.6"
   sudo: false
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,10 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
-      before_install:
-        - echo $PATH
+      env:
+        # NB: Trusty image comes with Python 3.4 installed, but we require 3.6+.
+        # Force 3.6 to the front of the PATH so it gets resolved by ci.py correctly.
+        - PATH="/opt/pyenv/shims/python3.6:${PATH}"
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ osx_setup: &osx_setup
     - >
       PYENV_ROOT="${HOME}/.pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
-    - >
       # These flags are necessary to get OpenSSL working. See
       # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
       PATH="/usr/local/opt/openssl/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 script:
   - ./ci.py --pants-version unspecified
-  - ./ci.py --pants-version pants.ini
+  - ./ci.py --pants-version config
 
 osx_setup: &osx_setup
   os: osx

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import argparse
+import os
+import subprocess
+from contextlib import contextmanager
+from enum import Enum
+
+
+class PantsVersion(Enum):
+  unspecified = "unspecified"
+  pants_ini = "pants.ini"
+
+  def __str__(self):
+      return self.value
+
+
+class PythonVersion(Enum):
+  unspecified = "unspecified"
+  py27 = "2.7"
+  py36 = "3.6"
+  py37 = "3.7"
+  
+  def __str__(self):
+    return self.value
+
+
+PANTS_INI = 'pants.ini'
+
+
+def main() -> None:
+  args = create_parser().parse_args()
+  run_tests(pants_version=args.pants_version, python_version=args.python_version)
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description="Utility to run CI for the setup repo."
+  )
+  parser.add_argument(
+      "--pants-version",
+      action="store",
+      type=PantsVersion,
+      choices=list(PantsVersion),
+      required=True,
+      help="Pants version to configure ./pants to use."
+  )
+  parser.add_argument(
+      "--python-version",
+      action="store",
+      type=PythonVersion,
+      choices=list(PythonVersion),
+      required=True,
+      help="Python version to configure ./pants to use."
+  )
+  return parser
+
+
+def run_tests(*, pants_version: PantsVersion, python_version: PythonVersion) -> None:
+  version_command = ["./pants", "--version"]
+  list_command = ["./pants", "list", "::"]
+  with setup_pants_version(pants_version):
+    with setup_python_version(python_version):
+      # NB: this env must be defined within the context manager setup_python_version()
+      # to pick up its changes. Once we change the context manager to instead modify
+      # pants.ini, we should move this line back up to the root level of this function.
+      env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
+      subprocess.run(version_command)
+      subprocess.run(list_command)
+      subprocess.run(version_command, env=env_with_pantsd)
+      subprocess.run(list_command, env=env_with_pantsd)
+
+
+@contextmanager
+def setup_pants_version(pants_version: PantsVersion):
+  """Modify pants.ini to allow the pants version to be unspecified or what it originally was in pants.ini."""
+  with open(PANTS_INI, 'r') as f:
+    original_pants_ini = list(f.readlines())
+  pants_version_line_index = next(
+    (i for i, line in enumerate(original_pants_ini) if line.startswith("pants_version:")),
+    None
+  )
+  if pants_version == PantsVersion.pants_ini and pants_version_line_index is None:
+    raise ValueError("You requested to use the pants_version from pants.ini for this test, but pants.ini "
+                     "does not include a pants_version! Please update pants.ini and run again.")
+  if pants_version == PantsVersion.unspecified and pants_version_line_index is not None:
+    with open(PANTS_INI, 'w') as f:
+      f.writelines(line for i, line in enumerate(original_pants_ini) if i != pants_version_line_index)
+  yield
+  with open(PANTS_INI, 'w') as f:
+    f.writelines(original_pants_ini)    
+
+
+@contextmanager
+def setup_python_version(python_version: PythonVersion):
+  # TODO: modify this test to change pants.ini like we do in setup_pants_version!
+  # Right now we are only testing that the virtual environment resolves properly, and
+  # can't yet test that we parse pants.ini correctly until https://github.com/pantsbuild/pants/pull/7363
+  # gets merged and is released with Pants.
+  original_env = os.environ
+  if python_version != PythonVersion.unspecified:
+    os.environ = {**original_env, "PYTHON": f"python{python_version.value}"}
+  yield
+  os.environ = original_env   
+
+
+if __name__ == "__main__":
+  main()

--- a/ci.py
+++ b/ci.py
@@ -9,15 +9,15 @@ from contextlib import contextmanager
 from enum import Enum
 
 
+PANTS_INI = 'pants.ini'
+
+
 class PantsVersion(Enum):
   unspecified = "unspecified"
   pants_ini = "pants.ini"
 
   def __str__(self):
       return self.value
-
-
-PANTS_INI = 'pants.ini'
 
 
 def main() -> None:

--- a/ci.py
+++ b/ci.py
@@ -17,22 +17,12 @@ class PantsVersion(Enum):
       return self.value
 
 
-class PythonVersion(Enum):
-  unspecified = "unspecified"
-  py27 = "2.7"
-  py36 = "3.6"
-  py37 = "3.7"
-  
-  def __str__(self):
-    return self.value
-
-
 PANTS_INI = 'pants.ini'
 
 
 def main() -> None:
   args = create_parser().parse_args()
-  run_tests(pants_version=args.pants_version, python_version=args.python_version)
+  run_tests(pants_version=args.pants_version)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -47,63 +37,35 @@ def create_parser() -> argparse.ArgumentParser:
       required=True,
       help="Pants version to configure ./pants to use."
   )
-  parser.add_argument(
-      "--python-version",
-      action="store",
-      type=PythonVersion,
-      choices=list(PythonVersion),
-      required=True,
-      help="Python version to configure ./pants to use."
-  )
   return parser
 
 
-def run_tests(*, pants_version: PantsVersion, python_version: PythonVersion) -> None:
+def run_tests(*, pants_version: PantsVersion) -> None:
   version_command = ["./pants", "--version"]
   list_command = ["./pants", "list", "::"]
+  env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
   with setup_pants_version(pants_version):
-    with setup_python_version(python_version):
-      # NB: this env must be defined within the context manager setup_python_version()
-      # to pick up its changes. Once we change the context manager to instead modify
-      # pants.ini, we should move this line back up to the root level of this function.
-      env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
-      subprocess.run(version_command)
-      subprocess.run(list_command)
-      subprocess.run(version_command, env=env_with_pantsd)
-      subprocess.run(list_command, env=env_with_pantsd)
+    subprocess.run(version_command)
+    subprocess.run(list_command)
+    subprocess.run(version_command, env=env_with_pantsd)
+    subprocess.run(list_command, env=env_with_pantsd)
 
 
 @contextmanager
 def setup_pants_version(pants_version: PantsVersion):
-  """Modify pants.ini to allow the pants version to be unspecified or what it originally was in pants.ini."""
+  """Modify pants.ini to allow the pants version to be unspecified or keep what was originally there."""
   with open(PANTS_INI, 'r') as f:
     original_pants_ini = list(f.readlines())
-  pants_version_line_index = next(
-    (i for i, line in enumerate(original_pants_ini) if line.startswith("pants_version:")),
-    None
-  )
-  if pants_version == PantsVersion.pants_ini and pants_version_line_index is None:
+  pants_version_specified = any(line.startswith("pants_version:") for line in original_pants_ini)
+  if pants_version == PantsVersion.pants_ini and not pants_version_specified:
     raise ValueError("You requested to use the pants_version from pants.ini for this test, but pants.ini "
                      "does not include a pants_version! Please update pants.ini and run again.")
-  if pants_version == PantsVersion.unspecified and pants_version_line_index is not None:
+  if pants_version == PantsVersion.unspecified and pants_version_specified:
     with open(PANTS_INI, 'w') as f:
-      f.writelines(line for i, line in enumerate(original_pants_ini) if i != pants_version_line_index)
+      f.writelines(line for line in original_pants_ini if "pants_version" not in line)
   yield
   with open(PANTS_INI, 'w') as f:
     f.writelines(original_pants_ini)    
-
-
-@contextmanager
-def setup_python_version(python_version: PythonVersion):
-  # TODO: modify this test to change pants.ini like we do in setup_pants_version!
-  # Right now we are only testing that the virtual environment resolves properly, and
-  # can't yet test that we parse pants.ini correctly until https://github.com/pantsbuild/pants/pull/7363
-  # gets merged and is released with Pants.
-  original_env = os.environ
-  if python_version != PythonVersion.unspecified:
-    os.environ = {**original_env, "PYTHON": f"python{python_version.value}"}
-  yield
-  os.environ = original_env   
 
 
 if __name__ == "__main__":

--- a/ci.py
+++ b/ci.py
@@ -65,7 +65,7 @@ def setup_pants_version(pants_version: PantsVersion):
       f.writelines(line for line in original_pants_ini if "pants_version" not in line)
   yield
   with open(PANTS_INI, 'w') as f:
-    f.writelines(original_pants_ini)    
+    f.writelines(original_pants_ini)
 
 
 if __name__ == "__main__":

--- a/ci.py
+++ b/ci.py
@@ -60,6 +60,8 @@ def setup_pants_version(pants_version: PantsVersion):
                      "does not include a pants_version! Please update pants.ini and run again.")
   if pants_version == PantsVersion.unspecified and pants_version_specified:
     with open(PANTS_INI, 'w') as f:
+      # NB: we must not only remove the original definition of `pants_version`, but also
+      # any lines that make use of it, such as contrib packages pinning their version to `pants_version`.
       f.writelines(line for line in original_pants_ini if "pants_version" not in line)
   yield
   with open(PANTS_INI, 'w') as f:

--- a/ci.py
+++ b/ci.py
@@ -14,7 +14,7 @@ PANTS_INI = 'pants.ini'
 
 class PantsVersion(Enum):
   unspecified = "unspecified"
-  pants_ini = "pants.ini"
+  config = "config"
 
   def __str__(self):
       return self.value
@@ -55,7 +55,7 @@ def setup_pants_version(test_pants_version: PantsVersion):
   with open(PANTS_INI, 'r') as f:
     original_pants_ini = list(f.readlines())
   pants_version_already_specified = any(line.startswith("pants_version:") for line in original_pants_ini)
-  if test_pants_version == PantsVersion.pants_ini and not pants_version_already_specified:
+  if test_pants_version == PantsVersion.config and not pants_version_already_specified:
     raise ValueError("You requested to use the pants_version from pants.ini for this test, but pants.ini "
                      "does not include a pants_version! Please update pants.ini and run again.")
   if test_pants_version == PantsVersion.unspecified and pants_version_already_specified:

--- a/ci.py
+++ b/ci.py
@@ -26,9 +26,7 @@ def main() -> None:
 
 
 def create_parser() -> argparse.ArgumentParser:
-  parser = argparse.ArgumentParser(
-    description="Utility to run CI for the setup repo."
-  )
+  parser = argparse.ArgumentParser(description="Utility to run CI for the setup repo.")
   parser.add_argument(
       "--pants-version",
       action="store",

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.10.0.dev2
+pants_version: 1.14.0
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.14.0
+pants_version: 1.15.0.dev3
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',


### PR DESCRIPTION
### Problem
The `./pants` script claims to support running with both a pinned `pants_version` in the `pants.ini` and with the `pants_version` unspecified.

We currently do not test this unspecified branch, which we should be doing to guarantee that functionality always works.

Further, this is pre-work for https://github.com/pantsbuild/setup/pull/32, which will add `--python-version` as another parameter for `ci.py` to allow an unspecified Python version vs. `pants.ini` specifying 2.7 or 3.6 (FYI resulting [`.travis.yml`](https://github.com/pantsbuild/setup/pull/32/files#diff-354f30a63fb0907d4ad57269548329e3)).

### Solution
Introduce a new `ci.py` helper script that uses argparse to have the parameter `--pants-version {unspecified,config}`.

#### Requires adding Python 3 to CI shards
Because this script uses modern Python 3—i.e. enums, f-strings, type hints, keyword-only args, and `subprocess.run()`—it requires Python 3.5+ to run.

Even though we can't yet run `./pants` with Python 3 until https://github.com/pantsbuild/setup/pull/32 lands, this PR does some of the pre-work in adding Python 3 to each of the shards so that we can run this script. This is valid to do because every single shard is going to run the tests with both Py27 and Py36—unlike Pants where we have dedicated shards for each interpreter—so there is only benefit in ensuring each shard has Py27 and Py36.

#### Also updates test's pinned `pants_version`