### PR TITLE
Hotfix for #33 to propagate subprocess return code and consistently use Py36 in Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ matrix:
       <<: *linux_setup
       dist: precise
       sudo: required
+      before_install:
+        - pyenv versions
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -68,3 +70,5 @@ matrix:
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup
       dist: xenial
+      before_install:
+        - pyenv versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ osx_setup: &osx_setup
       git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
       && ${PYENV_ROOT}/bin/pyenv install 3.6.8
       && ${PYENV_ROOT}/bin/pyenv global 3.6.8
+  before_script:
+    # Override file handler and thread limits
+    - ulimit -c unlimited
+    - ulimit -n 8192
 
 linux_setup: &linux_setup
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,17 @@ osx_setup: &osx_setup
       packages:
         - openssl
   env:
-    - >
+    - &env_pyenv >
       PYENV_ROOT="${HOME}/.pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
+    - >
       # These flags are necessary to get OpenSSL working. See
       # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - >
+    - &pyenv_install >
       git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
       && ${PYENV_ROOT}/bin/pyenv install 3.6.8
       && ${PYENV_ROOT}/bin/pyenv global 3.6.8
@@ -37,6 +38,10 @@ linux_setup: &linux_setup
   python:
     - "2.7"
     - "3.6"
+  # Modern Linux images come with Pyenv and some Python versions pre-installed.
+  # We must set `pyenv global` to use Python 3.6 instead of others like 3.5.
+  before_install:
+    - pyenv global ${PY27_VERSION} ${PY36_VERSION}
 
 matrix:
   include:
@@ -56,19 +61,23 @@ matrix:
       <<: *linux_setup
       dist: precise
       sudo: required
+      # NB: Precise image does not come with Pyenv, so we must manually install it
+      # as we do on OSX to get Python 3.6.
+      env:
+        - *env_pyenv
       before_install:
-        - pyenv versions
+        - *pyenv_install
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
-      before_install:
-        # NB: Trusty image comes with system Python 3.4, but we require 3.6+.
-        # Use pyenv global to ensure we use 2.7 and 3.6, not 3.4.
-        - pyenv global 2.7.14 3.6.3
+      env:
+        - PY27_VERSION=2.7.14
+        - PY36_VERSION=3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup
       dist: xenial
-      before_install:
-        - pyenv versions
+      env:
+        - PY27_VERSION=2.7.15
+        - PY36_VERSION=3.6.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ linux_setup: &linux_setup
     - "2.7"
     - "3.6"
   # Modern Linux images come with Pyenv and some Python versions pre-installed.
-  # We must set `pyenv global` to use Python 3.6 instead of others like 3.5.
+  # We set `pyenv global` to use Python 3.6 instead of others like 3.5.
   before_install:
     - pyenv global ${PY27_VERSION} ${PY36_VERSION}
 

--- a/ci.py
+++ b/ci.py
@@ -43,10 +43,10 @@ def run_tests(*, test_pants_version: PantsVersion) -> None:
   list_command = ["./pants", "list", "::"]
   env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
   with setup_pants_version(test_pants_version):
-    subprocess.run(version_command).check_returncode()
-    subprocess.run(list_command).check_returncode()
-    subprocess.run(version_command, env=env_with_pantsd).check_returncode()
-    subprocess.run(list_command, env=env_with_pantsd).check_returncode()
+    subprocess.run(version_command, check=True)
+    subprocess.run(list_command, check=True)
+    subprocess.run(version_command, env=env_with_pantsd, check=True)
+    subprocess.run(list_command, env=env_with_pantsd, check=True)
 
 
 @contextmanager

--- a/ci.py
+++ b/ci.py
@@ -70,4 +70,3 @@ def setup_pants_version(test_pants_version: PantsVersion):
 
 if __name__ == "__main__":
   main()
-  print(f"f-strings rock! {1+1}")

--- a/ci.py
+++ b/ci.py
@@ -70,3 +70,4 @@ def setup_pants_version(test_pants_version: PantsVersion):
 
 if __name__ == "__main__":
   main()
+  print(f"f-strings rock! {1+1}")

--- a/ci.py
+++ b/ci.py
@@ -43,10 +43,10 @@ def run_tests(*, test_pants_version: PantsVersion) -> None:
   list_command = ["./pants", "list", "::"]
   env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
   with setup_pants_version(test_pants_version):
-    subprocess.run(version_command)
-    subprocess.run(list_command)
-    subprocess.run(version_command, env=env_with_pantsd)
-    subprocess.run(list_command, env=env_with_pantsd)
+    subprocess.run(version_command).check_returncode()
+    subprocess.run(list_command).check_returncode()
+    subprocess.run(version_command, env=env_with_pantsd).check_returncode()
+    subprocess.run(list_command, env=env_with_pantsd).check_returncode()
 
 
 @contextmanager


### PR DESCRIPTION
https://github.com/pantsbuild/setup/pull/33 does not propagate return codes for subprocesses, meaning if the `./pants foo` commands fail, the error will print out to the screen but Travis will show everything as working. Fix this by adding `.check_returncode()`.

Also we found Linux Trusty and Xenial were using Python 3.5 to execute `ci.py`, as they err when introducing `f-strings`, which are 3.6+. So, use `pyenv global` to consistently use the correct interpreters.