### PR TITLE
Refactor `./pants` and fix bugs in `ci.py` in preparation for Python 3 support

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -77,7 +77,7 @@ def read_config() -> configparser.ConfigParser:
 
 def write_config(config: configparser.ConfigParser) -> None:
   with open(PANTS_INI, 'w') as f:
-    config.write(f, space_around_delimiters=False)
+    config.write(f)
 
 
 if __name__ == "__main__":

--- a/ci.py
+++ b/ci.py
@@ -61,12 +61,17 @@ def setup_pants_version(test_pants_version: PantsVersion):
     updated_config.remove_option(GLOBAL_SECTION, config_entry)
     # NB: We also remove plugins as they refer to the pants_version.
     updated_config.remove_option(GLOBAL_SECTION, "plugins")
+    write_config(updated_config)
   elif test_pants_version == PantsVersion.config:
     if config_entry not in original_config[GLOBAL_SECTION]:
       raise ValueError("You requested to use the pants_version from pants.ini for this test, but pants.ini "
                        "does not include a pants_version!")
-  yield
-  write_config(original_config)
+  try:
+    yield
+  except subprocess.CalledProcessError:
+    raise
+  finally:
+    write_config(original_config)
 
 
 def read_config() -> configparser.ConfigParser:

--- a/pants
+++ b/pants
@@ -48,18 +48,16 @@ function get_pants_ini_config_value {
   valid_delimiters="[:=]"
   optional_space="[[:space:]]*"
   prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-  remove_prefix=" s#${prefix}##p"
-  sed -ne "/${prefix}/${remove_prefix}" pants.ini
+  sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
 }
 
 function determine_pants_runtime_python_version {
   python_bin_name="${PYTHON:-python2.7}"
-  if which "${python_bin_name}" >/dev/null; then
-    echo "$(which ${python_bin_name})"
-  else
+  if ! which "${python_bin_name}" >/dev/null; then
     echo "${python_bin_name} could not be found on your PATH! Pants will not work." 1>&2
     exit 1
   fi
+  echo "$(which ${python_bin_name})"
 }
 
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
@@ -113,7 +111,7 @@ function bootstrap_pants {
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd -P)"
 python="$(determine_pants_runtime_python_version)"
-pants_dir="$(bootstrap_pants ${python})"
+pants_dir="$(bootstrap_pants "${python}")"
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non

--- a/pants
+++ b/pants
@@ -57,7 +57,6 @@ function determine_pants_runtime_python_version {
     echo "Could not find ${python_bin_name}. Please ensure ${python_bin_name} is on your PATH." 1>&2
     exit 1
   fi
-  echo "$(which ${python_bin_name})"
 }
 
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX

--- a/pants
+++ b/pants
@@ -13,8 +13,6 @@
 
 set -eou pipefail
 
-PYTHON=${PYTHON:-$(which python2.7)}
-
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
@@ -45,6 +43,16 @@ function tempdir {
   mktemp -d "$1"/pants.XXXXXX
 }
 
+function determine_pants_runtime_python_version {
+	  python_bin_name="${PYTHON:-python2.7}"
+	  if which "${python_bin_name}" >/dev/null; then
+	    echo "$(which ${python_bin_name})"
+	  else
+	    echo "${python_bin_name} could not be found on your PATH! Pants will not work." 1>&2
+	    exit 1
+	  fi
+	}
+
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
@@ -64,6 +72,7 @@ function bootstrap_venv {
 }
 
 function bootstrap_pants {
+  python="$1"
   pants_requirement="pantsbuild.pants"
   pants_version=$(
     grep -E "^[[:space:]]*pants_version" pants.ini 2>/dev/null | \
@@ -83,7 +92,7 @@ function bootstrap_pants {
       # ${SETUPTOOLS_REQUIREMENT} wins.
       venv_path="$(bootstrap_venv)"
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-      "${PYTHON}" "${venv_path}/virtualenv.py" --no-setuptools --no-download \
+      "${python}" "${venv_path}/virtualenv.py" --no-setuptools --no-download \
         "${staging_dir}/install"
       "${staging_dir}/install/bin/pip" install -U pip
       "${staging_dir}/install/bin/pip" install "${SETUPTOOLS_REQUIREMENT}"
@@ -97,7 +106,8 @@ function bootstrap_pants {
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd -P)"
-pants_dir="$(bootstrap_pants)"
+python="$(determine_pants_runtime_python_version)"
+pants_dir="$(bootstrap_pants ${python})"
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non

--- a/pants
+++ b/pants
@@ -53,8 +53,7 @@ function get_pants_ini_config_value {
 
 function determine_pants_runtime_python_version {
   python_bin_name="${PYTHON:-python2.7}"
-  if ! which "${python_bin_name}" >/dev/null; then
-    echo "${python_bin_name} could not be found on your PATH! Pants will not work." 1>&2
+  if ! which "${python_bin_name}"; then
     exit 1
   fi
   echo "$(which ${python_bin_name})"
@@ -81,7 +80,7 @@ function bootstrap_venv {
 function bootstrap_pants {
   python="$1"
   pants_requirement="pantsbuild.pants"
-  pants_version=$(get_pants_ini_config_value 'pants_version')
+  pants_version="$(get_pants_ini_config_value 'pants_version')"
   if [[ -n "${pants_version}" ]]; then
     pants_requirement="${pants_requirement}==${pants_version}"
   else

--- a/pants
+++ b/pants
@@ -49,8 +49,7 @@ function tempdir {
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
 function bootstrap_venv {
-  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]
-  then
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]; then
     (
       mkdir -p "${PANTS_BOOTSTRAP}"
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
@@ -70,15 +69,15 @@ function bootstrap_pants {
     grep -E "^[[:space:]]*pants_version" pants.ini 2>/dev/null | \
       cut -f2 -d: | tr -d " "
   )
-  if [[ -n "${pants_version}" ]]
-  then
+  if [[ -n "${pants_version}" ]]; then
     pants_requirement="${pants_requirement}==${pants_version}"
   else
     pants_version="unspecified"
   fi
 
-  if [[ ! -d "${PANTS_BOOTSTRAP}/${pants_version}" ]]
-  then
+  target_folder_name="${pants_version}"
+
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
     (
       # NB: We setup the virtualenv with no setuptools to ensure our
       # ${SETUPTOOLS_REQUIREMENT} wins.
@@ -89,16 +88,16 @@ function bootstrap_pants {
       "${staging_dir}/install/bin/pip" install -U pip
       "${staging_dir}/install/bin/pip" install "${SETUPTOOLS_REQUIREMENT}"
       "${staging_dir}/install/bin/pip" install "${pants_requirement}"
-      ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}"
-      mv "${staging_dir}/${pants_version}" "${PANTS_BOOTSTRAP}/${pants_version}"
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
+      mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"
     ) 1>&2
   fi
-  echo "${PANTS_BOOTSTRAP}/${pants_version}"
+  echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
 }
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd -P)"
-pants_dir=$(bootstrap_pants)
+pants_dir="$(bootstrap_pants)"
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non

--- a/pants
+++ b/pants
@@ -54,6 +54,7 @@ function get_pants_ini_config_value {
 function determine_pants_runtime_python_version {
   python_bin_name="${PYTHON:-python2.7}"
   if ! which "${python_bin_name}"; then
+    echo "Could not find ${python_bin_name}. Please ensure ${python_bin_name} is on your PATH." 1>&2
     exit 1
   fi
   echo "$(which ${python_bin_name})"

--- a/pants
+++ b/pants
@@ -13,6 +13,8 @@
 
 set -eou pipefail
 
+PYTHON_BIN_NAME="${PYTHON:-python2.7}"
+
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
@@ -70,11 +72,10 @@ function get_pants_ini_config_value {
 # are installed and up to date.
 
 function determine_pants_runtime_python_version {
-  python_bin_name="${PYTHON:-python2.7}"
-  if which "${python_bin_name}" >/dev/null; then
-    which "${python_bin_name}"
+  if which "${PYTHON_BIN_NAME}" >/dev/null; then
+    which "${PYTHON_BIN_NAME}"
   else
-    die "Could not find ${python_bin_name}. Please ensure ${python_bin_name} is on your PATH."
+    die "Could not find ${PYTHON_BIN_NAME}. Please ensure ${PYTHON_BIN_NAME} is on your PATH."
   fi
 }
 
@@ -121,6 +122,7 @@ function bootstrap_pants {
       "${staging_dir}/install/bin/pip" install "${pants_requirement}"
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
       mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"
+      green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."
     ) 1>&2
   fi
   echo "${PANTS_BOOTSTRAP}/${target_folder_name}"

--- a/pants
+++ b/pants
@@ -31,13 +31,22 @@ SETUPTOOLS_REQUIREMENT="setuptools==5.4.1"
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz
 
-# The high-level flow:
-# 1.) Grab pants version from pants.ini or default to latest.
-# 2.) Check for a venv via a naming/path convention and execute if found.
-# 3.) Otherwise create venv and re-exec self.
-#
-# After that pants itself will handle making sure any requested plugins
-# are installed and up to date.
+COLOR_BLUE="\x1b[34m"
+COLOR_RED="\x1b[31m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
 
 function tempdir {
   mktemp -d "$1"/pants.XXXXXX
@@ -51,11 +60,21 @@ function get_pants_ini_config_value {
   sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
 }
 
+# The high-level flow:
+# 1.) Resolve the Python interpreter, defaulting to `python2.7`.
+# 2.) Grab pants version from pants.ini or default to latest.
+# 3.) Check for a venv via a naming/path convention and execute if found.
+# 4.) Otherwise create venv and re-exec self.
+#
+# After that pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
 function determine_pants_runtime_python_version {
   python_bin_name="${PYTHON:-python2.7}"
-  if ! which "${python_bin_name}"; then
-    echo "Could not find ${python_bin_name}. Please ensure ${python_bin_name} is on your PATH." 1>&2
-    exit 1
+  if which "${python_bin_name}" >/dev/null; then
+    which "${python_bin_name}"
+  else
+    die "Could not find ${python_bin_name}. Please ensure ${python_bin_name} is on your PATH."
   fi
 }
 

--- a/pants
+++ b/pants
@@ -31,8 +31,8 @@ SETUPTOOLS_REQUIREMENT="setuptools==5.4.1"
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz
 
-COLOR_BLUE="\x1b[34m"
 COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
 COLOR_RESET="\x1b[0m"
 
 function log() {

--- a/pants
+++ b/pants
@@ -53,14 +53,14 @@ function get_pants_ini_config_value {
 }
 
 function determine_pants_runtime_python_version {
-	  python_bin_name="${PYTHON:-python2.7}"
-	  if which "${python_bin_name}" >/dev/null; then
-	    echo "$(which ${python_bin_name})"
-	  else
-	    echo "${python_bin_name} could not be found on your PATH! Pants will not work." 1>&2
-	    exit 1
-	  fi
-	}
+  python_bin_name="${PYTHON:-python2.7}"
+  if which "${python_bin_name}" >/dev/null; then
+    echo "$(which ${python_bin_name})"
+  else
+    echo "${python_bin_name} could not be found on your PATH! Pants will not work." 1>&2
+    exit 1
+  fi
+}
 
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
 # functions.  Any tmp dir w/o a symlink pointing to it can go.

--- a/pants
+++ b/pants
@@ -43,6 +43,15 @@ function tempdir {
   mktemp -d "$1"/pants.XXXXXX
 }
 
+function get_pants_ini_config_value {
+  config_key="$1"
+  valid_delimiters="[:=]"
+  optional_space="[[:space:]]*"
+  prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
+  remove_prefix=" s#^.*${valid_delimiters}${optional_space}##p"
+  sed -ne "/${prefix}/${remove_prefix}" pants.ini
+}
+
 function determine_pants_runtime_python_version {
 	  python_bin_name="${PYTHON:-python2.7}"
 	  if which "${python_bin_name}" >/dev/null; then
@@ -74,10 +83,7 @@ function bootstrap_venv {
 function bootstrap_pants {
   python="$1"
   pants_requirement="pantsbuild.pants"
-  pants_version=$(
-    grep -E "^[[:space:]]*pants_version" pants.ini 2>/dev/null | \
-      cut -f2 -d: | tr -d " "
-  )
+  pants_version=$(get_pants_ini_config_value 'pants_version')
   if [[ -n "${pants_version}" ]]; then
     pants_requirement="${pants_requirement}==${pants_version}"
   else

--- a/pants
+++ b/pants
@@ -48,7 +48,7 @@ function get_pants_ini_config_value {
   valid_delimiters="[:=]"
   optional_space="[[:space:]]*"
   prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-  remove_prefix=" s#^.*${valid_delimiters}${optional_space}##p"
+  remove_prefix=" s#${prefix}##p"
   sed -ne "/${prefix}/${remove_prefix}" pants.ini
 }
 

--- a/pants.ini
+++ b/pants.ini
@@ -1,6 +1,6 @@
 [GLOBAL]
-pants_version:1.15.0.dev3
-plugins:[
+pants_version : 1.15.0.dev3
+plugins : [
 	'pantsbuild.pants.contrib.go==%(pants_version)s',
 	]
 


### PR DESCRIPTION
This makes several improvements and fixes that will result in a smaller diff for https://github.com/pantsbuild/setup/pull/32.

Fixes:
- Fix missing `write_config(updated_config)` when setting up `pants_version`, meaning when running `./ci.py --unspecified` we wouldn't actually remove the `pants_version` from `pants.ini`. This hotfixes https://github.com/pantsbuild/setup/pull/35.
- Properly restore `pants.ini` in CI, even if the subprocesses failed. Due to https://github.com/pantsbuild/setup/pull/34 now properly propagating return codes, the context manager would exit prematurely before restoring the original `pants.ini`.

Refactors:
- Check the Python interpreter is on the PATH and exit with error message if not.
- Extract Python interpreter setup into a dedicated function `determine_pants_runtime_python_version()` for a smaller diff with #32.
- Improve `pants.ini` parsing:
   - Extract `get_pants_ini_config_value()` to generify reading `pants.ini`.
   - Extend `pants.ini` parsing to recognize both `:` and `=`, along with optional spaces before and/or after the delimiter. These were all valid `ini` entries, but our script only handled one specific case.
   - Respect `#` in front of `pants_version` by requiring the line to start exactly with `pants_version`.
- Refactor `pants.ini` parsing to use variables for readability.
- Add `green` and `die` functions with colored output
   - Use `die` if interpreter cannot be resolved
   - Use `green` upon successful creation of a new virtual environment the first time
