### PR TITLE
Install Python 3.7 on Xenial and all OSX CI shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 script:
   - python2.7 --version
   - python3.6 --version
-  - which python3.7 >/dev/null && python3.7 --version
+  - if which python3.7 >/dev/null; then python3.7 --version; fi
   # - ./ci.py --pants-version unspecified
   # - ./ci.py --pants-version config
 
@@ -94,6 +94,9 @@ matrix:
       before_install:
         - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
         - pyenv update
+        - pyenv versions
+        - pyenv install --list
+        - pyenv install "${PYENV_PY37_VERSION}"
         - pyenv global 2.7.14 3.6.3 "${PYENV_PY37_VERSION}"
 
     - name: "Ubuntu 16.04 - Xenial"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ osx_setup: &osx_setup
       && "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
     - &pyenv_install_py37 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && "${PYENV_BIN}" install"${PYENV_PY37_VERSION}"
-    - "${PYENV_BIN}" global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+      && "${PYENV_BIN}" install" ${PYENV_PY37_VERSION}"
+    - ${PYENV_BIN} global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -78,7 +78,7 @@ matrix:
         - *env_pyenv
       before_install:
         - *pyenv_install_py36
-        - "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
+        - ${PYENV_BIN} global "${PYENV_PY36_VERSION}"
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ branches:
     - gh-pages
 
 script:
-  - ./ci.py --pants-version unspecified
-  - ./ci.py --pants-version config
+  - python2.7 --version
+  - python3.6 --version
+  - python3.7 --version
+  # - ./ci.py --pants-version unspecified
+  # - ./ci.py --pants-version config
 
 osx_setup: &osx_setup
   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ osx_setup: &osx_setup
       && "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
     - &pyenv_install_py37 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && "${PYENV_BIN}" install" ${PYENV_PY37_VERSION}"
+      && "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
     - ${PYENV_BIN} global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,9 @@ matrix:
       env:
         - *env_pyenv
       before_install:
-        - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
-        - pyenv update
-        - pyenv versions
-        - pyenv install --list
-        - pyenv install "${PYENV_PY37_VERSION}"
-        - pyenv global 2.7.14 3.6.3 "${PYENV_PY37_VERSION}"
+        - *pyenv_install_py36
+        - *pyenv_install_py37
+        - pyenv global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 script:
   # Linux Precise and Trusty cannot install Python 3.7 due to an outdated OpenSSL,
   # so we set this variable to allow skipping Python 3.7 on these shards.
+  - python37_present="$(if which python3.7 >/dev/null; then echo 'true'; else echo 'false'; fi)"
   - ./ci.py --pants-version unspecified
   - ./ci.py --pants-version config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ env:
     - PYENV_PY37_VERSION=3.7.2
 
 script:
+  - python37_present="$(if which python3.7 >/dev/null; then echo 'true'; else echo 'false'; fi)"
   - python2.7 --version
   - python3.6 --version
   # Linux Precise and Trusty cannot install Python 3.7 due to an outdated OpenSSL,
   # so we skip Python 3.7 on these shards
-  - if which python3.7 >/dev/null; then python3.7 --version; fi
+  - if [[ "${python37_present}" = 'true' ]]; then python3.7 --version; fi
   # - ./ci.py --pants-version unspecified
   # - ./ci.py --pants-version config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ osx_setup: &osx_setup
     - &pyenv_install >
       git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
       && ${PYENV_ROOT}/bin/pyenv install 3.6.8
-      && ${PYENV_ROOT}/bin/pyenv global 3.6.8
+      && ${PYENV_ROOT}/bin/pyenv install 3.7.2
+      && ${PYENV_ROOT}/bin/pyenv global 3.6.8 3.7.2
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -42,9 +43,12 @@ linux_setup: &linux_setup
   python:
     - "2.7"
     - "3.6"
+    - "3.7"
   # Modern Linux images come with Pyenv and some Python versions pre-installed.
-  # We set `pyenv global` to use Python 3.6 instead of others like 3.5.
+  # We set `pyenv global` to use Python 3.6 and 3.7 instead of others like 3.5.
   before_install:
+    - pyenv versions
+    - python3.7 --version
     - pyenv global ${PY27_VERSION} ${PY36_VERSION}
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,11 @@ matrix:
       <<: *linux_setup
       dist: precise
       sudo: required
+      addons:
+        apt:
+          packages:
+            - openssl
+            - libssl-dev
       env:
         - *env_pyenv
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 script:
   - python2.7 --version
   - python3.6 --version
+  # Linux Precise and Trusty cannot install Python 3.7 due to an outdated OpenSSL,
+  # so we skip Python 3.7 on these shards
   - if which python3.7 >/dev/null; then python3.7 --version; fi
   # - ./ci.py --pants-version unspecified
   # - ./ci.py --pants-version config
@@ -84,17 +86,8 @@ matrix:
       <<: *linux_setup
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - openssl
-            - libssl-dev
-      env:
-        - *env_pyenv
       before_install:
-        - *pyenv_install_py36
-        - *pyenv_install_py37
-        - ${PYENV_BIN} global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+        - pyenv global 2.7.14 3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ env:
     - PYENV_PY37_VERSION=3.7.2
 
 script:
-  - python37_present="$(if which python3.7 >/dev/null; then echo 'true'; else echo 'false'; fi)"
-  - python2.7 --version
-  - python3.6 --version
   # Linux Precise and Trusty cannot install Python 3.7 due to an outdated OpenSSL,
-  # so we skip Python 3.7 on these shards
-  - if [[ "${python37_present}" = 'true' ]]; then python3.7 --version; fi
-  # - ./ci.py --pants-version unspecified
-  # - ./ci.py --pants-version config
+  # so we set this variable to allow skipping Python 3.7 on these shards.
+  - ./ci.py --pants-version unspecified
+  - ./ci.py --pants-version config
 
 osx_setup: &osx_setup
   os: osx
@@ -86,7 +82,6 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
-      sudo: required
       before_install:
         - pyenv global 2.7.14 3.6.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ osx_setup: &osx_setup
         - openssl
   env:
     - &env_pyenv >
-      PYENV_ROOT="${HOME}/.pyenv"
+      PYENV_ROOT="${HOME}/.pants_pyenv"
       PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
     - >
@@ -94,7 +94,7 @@ matrix:
       before_install:
         - *pyenv_install_py36
         - *pyenv_install_py37
-        - pyenv global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+        - ${PYENV_BIN} global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,6 @@ linux_setup: &linux_setup
     - "2.7"
     - "3.6"
     - "3.7"
-  # Modern Linux images come with Pyenv and some Python versions pre-installed.
-  # We set `pyenv global` to use Python 3.6 and 3.7 instead of others like 3.5.
-  before_install:
-    - pyenv versions
-    - python3.7 --version
-    - pyenv global ${PY27_VERSION} ${PY36_VERSION}
 
 matrix:
   include:
@@ -69,8 +63,6 @@ matrix:
       <<: *linux_setup
       dist: precise
       sudo: required
-      # NB: Precise image does not come with Pyenv, so we must manually install it
-      # as we do on OSX to get Python 3.6.
       env:
         - *env_pyenv
       before_install:
@@ -79,13 +71,12 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
-      env:
-        - PY27_VERSION=2.7.14
-        - PY36_VERSION=3.6.3
+      before_install:
+        - pyenv install 3.7.2
+        - pyenv global 2.7.14 3.6.3 3.7.2
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup
       dist: xenial
-      env:
-        - PY27_VERSION=2.7.15
-        - PY36_VERSION=3.6.7
+      before_install:
+      - pyenv global 2.7.15 3.6.7 3.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ matrix:
       env:
         - *env_pyenv
       before_install:
-        - *pyenv_install_py36
+        # - *pyenv_install_py36
         - *pyenv_install_py37
-        - *pyenv_global_py36_py37
+        # - *pyenv_global_py36_py37
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ branches:
   only:
     - gh-pages
 
+env:
+  global:
+    - PYENV_PY36_VERSION=3.6.8
+    - PYENV_PY37_VERSION=3.7.2
+
 script:
   - python2.7 --version
   - python3.6 --version
-  - python3.7 --version
+  - which python3.7 >/dev/null && python3.7 --version
   # - ./ci.py --pants-version unspecified
   # - ./ci.py --pants-version config
 
@@ -31,11 +36,11 @@ osx_setup: &osx_setup
   before_install:
     - &pyenv_install_py36 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && ${PYENV_ROOT}/bin/pyenv install 3.6.8
+      && ${PYENV_ROOT}/bin/pyenv install "${PYENV_PY36_VERSION}"
     - &pyenv_install_py37 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && ${PYENV_ROOT}/bin/pyenv install 3.7.2
-    - &pyenv_global_py36_py37 ${PYENV_ROOT}/bin/pyenv global 3.6.8 3.7.2
+      && ${PYENV_ROOT}/bin/pyenv install"${PYENV_PY37_VERSION}"
+    - ${PYENV_ROOT}/bin/pyenv global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -76,9 +81,8 @@ matrix:
       env:
         - *env_pyenv
       before_install:
-        # - *pyenv_install_py36
-        - *pyenv_install_py37
-        # - *pyenv_global_py36_py37
+        - *pyenv_install_py36
+        - pyenv global "${PYENV_PY36_VERSION}"
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -87,7 +91,7 @@ matrix:
         - *env_pyenv
       before_install:
         - *pyenv_install_py37
-        - pyenv global 2.7.14 3.6.3 3.7.2
+        - pyenv global 2.7.14 3.6.3 "${PYENV_PY37_VERSION}"
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ osx_setup: &osx_setup
   env:
     - &env_pyenv >
       PYENV_ROOT="${HOME}/.pyenv"
+      PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
     - >
       # These flags are necessary to get OpenSSL working. See
@@ -36,11 +37,11 @@ osx_setup: &osx_setup
   before_install:
     - &pyenv_install_py36 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && ${PYENV_ROOT}/bin/pyenv install "${PYENV_PY36_VERSION}"
+      && "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
     - &pyenv_install_py37 >
       if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
-      && ${PYENV_ROOT}/bin/pyenv install"${PYENV_PY37_VERSION}"
-    - ${PYENV_ROOT}/bin/pyenv global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+      && "${PYENV_BIN}" install"${PYENV_PY37_VERSION}"
+    - "${PYENV_BIN}" global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -77,7 +78,7 @@ matrix:
         - *env_pyenv
       before_install:
         - *pyenv_install_py36
-        - pyenv global "${PYENV_PY36_VERSION}"
+        - "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -91,7 +92,8 @@ matrix:
       env:
         - *env_pyenv
       before_install:
-        - *pyenv_install_py37
+        - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+        - pyenv update
         - pyenv global 2.7.14 3.6.3 "${PYENV_PY37_VERSION}"
 
     - name: "Ubuntu 16.04 - Xenial"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,6 @@ matrix:
       <<: *linux_setup
       dist: precise
       sudo: required
-      addons:
-        apt:
-          packages:
-            - openssl
-            - libssl-dev
       env:
         - *env_pyenv
       before_install:
@@ -87,6 +82,12 @@ matrix:
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - openssl
+            - libssl-dev
       env:
         - *env_pyenv
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,13 @@ osx_setup: &osx_setup
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - &pyenv_install >
-      git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
+    - &pyenv_install_py36 >
+      if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
       && ${PYENV_ROOT}/bin/pyenv install 3.6.8
+    - &pyenv_install_py37 >
+      if [ ! -d "${PYENV_ROOT}" ]; then git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}; fi
       && ${PYENV_ROOT}/bin/pyenv install 3.7.2
-      && ${PYENV_ROOT}/bin/pyenv global 3.6.8 3.7.2
+    - &pyenv_global_py36_py37 ${PYENV_ROOT}/bin/pyenv global 3.6.8 3.7.2
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -74,14 +76,18 @@ matrix:
       env:
         - *env_pyenv
       before_install:
-        - *pyenv_install
+        - *pyenv_install_py36
+        - *pyenv_install_py37
+        - *pyenv_global_py36_py37
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
+      env:
+        - *env_pyenv
       before_install:
-        - pyenv install --list
-        - pyenv global 2.7.14 3.6.3
+        - *pyenv_install_py37
+        - pyenv global 2.7.14 3.6.3 3.7.2
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ matrix:
       <<: *linux_setup
       dist: trusty
       before_install:
-        - pyenv install 3.7.2
-        - pyenv global 2.7.14 3.6.3 3.7.2
+        - pyenv install --list
+        - pyenv global 2.7.14 3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup


### PR DESCRIPTION
### Problem
Because we release `pantsbuild.pants` as a `cp36-abi3` wheel, we would expect it to work with Python 3.6+ once we land https://github.com/pantsbuild/setup/pull/32, so, we should test with 3.7 as a simple sanity check.

As prework for that, we need to ensure we have a Python 3.7 interpreter on every shard possible.

## Solution
Use a mix of pyenv and pre-installed Python versions to get 3.7 on every OSX shard and on Ubuntu Xenial (16.04).

Note we cannot get it on Ubuntu Precise (12.04) or Trusty (14.04) without significant trouble, as their OpenSSL version is too outdated. Even updating OpenSSL with `apt-get` does not solve the issue. Because users still using Precise—which is EOL since April 2017—or Trusty—which is EOL starting April 2019—are unlikely to be using the most modern Python possible, we accept that we can't test 3.7  and only test 2.7 and 3.6 on those two shards.

## Result
All shards but Precise and Trusty now have Python 3.7, as proven with this test run: https://travis-ci.org/pantsbuild/setup/builds/506415674.

This does slow down our CI for the OSX shards, as they now must install Python 3.7 in addition to Python 3.6. They each go from taking ~5.5 minutes to 8 minutes. Because this repo's CI is so fast already and we don't run PRs against it often, this tradeoff is well worth the benefit we get through increased test coverage.

As a followup PR, we could introduce caching to the `PYENV_ROOT` for OSX shards and Ubuntu Precise.