### PR TITLE
Skip flaky Pantsd tests for OSX 10.12 shard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ matrix:
     - name: "OSX 10.12 - Sierra"
       <<: *osx_setup
       osx_image: xcode9.2
+      # OSX 10.12 Sierra frequently flakes when running with Pantsd. Restore the original
+      # tests once https://github.com/pantsbuild/pants/issues/6714 and
+      # https://github.com/pantsbuild/pants/issues/7323 are resolved.
+      script:
+        - ./ci.py --pants-version unspecified --skip-pantsd-tests
+        - ./ci.py --pants-version config --skip-pantsd-tests
 
     - name: "OSX 10.13 - High Sierra"
       <<: *osx_setup

--- a/ci.py
+++ b/ci.py
@@ -24,7 +24,7 @@ class PantsVersion(Enum):
 
 def main() -> None:
   args = create_parser().parse_args()
-  run_tests(test_pants_version=args.pants_version)
+  run_tests(test_pants_version=args.pants_version, skip_pantsd_tests=args.skip_pantsd_tests)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -37,18 +37,20 @@ def create_parser() -> argparse.ArgumentParser:
       required=True,
       help="Pants version to configure ./pants to use."
   )
+  parser.add_argument("--skip-pantsd-tests", action="store_true")
   return parser
 
 
-def run_tests(*, test_pants_version: PantsVersion) -> None:
+def run_tests(*, test_pants_version: PantsVersion, skip_pantsd_tests: bool) -> None:
   version_command = ["./pants", "--version"]
   list_command = ["./pants", "list", "::"]
   env_with_pantsd = {**os.environ, "PANTS_ENABLE_PANTSD": "True"}
   with setup_pants_version(test_pants_version):
     subprocess.run(version_command, check=True)
     subprocess.run(list_command, check=True)
-    subprocess.run(version_command, env=env_with_pantsd, check=True)
-    subprocess.run(list_command, env=env_with_pantsd, check=True)
+    if not skip_pantsd_tests:
+      subprocess.run(version_command, env=env_with_pantsd, check=True)
+      subprocess.run(list_command, env=env_with_pantsd, check=True)
 
 
 @contextmanager


### PR DESCRIPTION
### Problem
Due to https://github.com/pantsbuild/pants/issues/6714, and maybe https://github.com/pantsbuild/pants/issues/7323, the OSX 12 shard frequently flakes when Pantsd is enabled, as seen [here](https://travis-ci.org/pantsbuild/setup/jobs/507257503#L432), [here](https://travis-ci.org/pantsbuild/setup/jobs/507238744#L545), and [here](https://travis-ci.org/pantsbuild/setup/jobs/507238744#L681).

This blocks https://github.com/pantsbuild/setup/pull/32, as that PR will result in each shard running with Pantsd a total of 6 more times, which results in an almost certain guarantee at least one shard will flake.

### Solution
Temporarily skip pantsd tests for OSX 10.12.

We do not completely remove the shard, as the first two tests still work and are useful to include.