### PR TITLE
Refactor ci.py to allow passing multiple args in one call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.pids/
 
 __pycache__/
+/.mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /.pids/
 
 __pycache__/
-/.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,14 @@ env:
     - PYENV_PY37_VERSION=3.7.2
 
 script:
-  # Linux Precise and Trusty cannot install Python 3.7 due to an outdated OpenSSL,
-  # so we set this variable to allow skipping Python 3.7 on these shards.
-  - python37_present="$(if which python3.7 >/dev/null; then echo 'true'; else echo 'false'; fi)"
-  - ./build-support/ci.py --pants-version unspecified --python-version unspecified
-  # TODO: these entries will not work until 1.15.0 is cut, as ./pants uses 1.14.0 currently
-  # when pants_version is unspecified. Add this test back once 1.15.0 is released.
-  # - ./build-support/ci.py --pants-version unspecified --python-version 2.7
-  # - ./build-support/ci.py --pants-version unspecified --python-version 3.6
-  # - if [[ "${python37_present}" = 'true' ]]; then
-  #    ./build-support/ci.py --pants-version unspecified --python-version 3.7; fi
-  - ./build-support/ci.py --pants-version config --python-version unspecified
-  - ./build-support/ci.py --pants-version config --python-version 2.7
-  - ./build-support/ci.py --pants-version config --python-version 3.6
-  - if [[ "${python37_present}" = 'true' ]]; then
-      ./build-support/ci.py --pants-version config --python-version 3.7; fi
+  # TODO: Once 1.15.0 is cut, consolidate this back into one entry. Currently the
+  # python version cannot be specified when the pants_version is unspecified.
+  - ./build-support/ci.py
+    --pants-versions unspecified
+    --python-versions unspecified
+  - ./build-support/ci.py
+    --pants-versions config
+    --python-versions unspecified 2.7 3.6 3.7
 
 osx_setup: &osx_setup
   os: osx
@@ -79,15 +72,15 @@ matrix:
       # tests once https://github.com/pantsbuild/pants/issues/6714 and
       # https://github.com/pantsbuild/pants/issues/7323 are resolved.
       script:
-        - ./build-support/ci.py --pants-version unspecified --python-version unspecified --skip-pantsd-tests
-        # TODO: add these once 1.15.0 is released.
-        # - ./build-support/ci.py --pants-version unspecified --python-version 2.7 --skip-pantsd-tests
-        # - ./build-support/ci.py --pants-version unspecified --python-version 3.6 --skip-pantsd-tests
-        # - ./build-support/ci.py --pants-version unspecified --python-version 3.7 --skip-pantsd-tests
-        - ./build-support/ci.py --pants-version config --python-version unspecified --skip-pantsd-tests
-        - ./build-support/ci.py --pants-version config --python-version 2.7 --skip-pantsd-tests
-        - ./build-support/ci.py --pants-version config --python-version 3.6 --skip-pantsd-tests
-        - ./build-support/ci.py --pants-version config --python-version 3.7 --skip-pantsd-tests
+        - ./build-support/ci.py
+          --pants-versions unspecified
+          --python-versions unspecified
+          --skip-pantsd-tests
+        - ./build-support/ci.py
+          --pants-versions config
+          --python-versions unspecified 2.7 3.6
+          --skip-pantsd-tests
+
 
     - name: "OSX 10.13 - High Sierra"
       <<: *osx_setup
@@ -102,12 +95,27 @@ matrix:
       before_install:
         - *pyenv_install_py36
         - ${PYENV_BIN} global "${PYENV_PY36_VERSION}"
+      script:
+        - ./build-support/ci.py
+          --pants-versions unspecified
+          --python-versions unspecified
+        - ./build-support/ci.py
+          --pants-versions config
+          --python-versions unspecified 2.7 3.6
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty
       before_install:
         - pyenv global 2.7.14 3.6.3
+      script:
+        - ./build-support/ci.py
+          --pants-versions unspecified
+          --python-versions unspecified
+        - ./build-support/ci.py
+          --pants-versions config
+          --python-versions unspecified 2.7 3.6
+
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -70,7 +70,8 @@ def run_tests_with_env(*,
     pants_version: PantsVersion, python_version: PythonVersion, skip_pantsd_tests: bool
   ) -> None:
   slug = f"Tests_{pants_version}_{python_version}"
-  with travis_section(slug, f"Running tests with `--pants-version={pants_version}` and `--python_version={python_version}`."):
+  banner_message = f"Running tests with `--pants-version={pants_version}` and `--python_version={python_version}`."
+  with travis_section(slug, banner_message):
     with setup_pants_version(pants_version):
       with setup_python_version(python_version):
         run_tests(skip_pantsd_tests=skip_pantsd_tests)

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -72,9 +72,8 @@ def run_tests_with_env(*,
   slug = f"Tests_{pants_version}_{python_version}"
   banner_message = f"Running tests with `--pants-version={pants_version}` and `--python_version={python_version}`."
   with travis_section(slug, banner_message):
-    with setup_pants_version(pants_version):
-      with setup_python_version(python_version):
-        run_tests(skip_pantsd_tests=skip_pantsd_tests)
+    with setup_pants_version(pants_version), setup_python_version(python_version):
+      run_tests(skip_pantsd_tests=skip_pantsd_tests)
 
 
 def run_tests(*, skip_pantsd_tests: bool) -> None:


### PR DESCRIPTION
### Problem
Typically, we want to run `ci.py` with multiple different environment configurations, such as ensuring it works with Python 2.7, 3.6, and 3.7. This currently means having to call the script again for each env.

This makes the script less flexible and results in more code in `.travis.yml`. It also makes the logs more verbose than necessary—ideally we would have a Travis fold for each new env, rather than the current behavior to fold for each individual subprocess run.

### Solution
Use argparse's `nargs` to allow this change.

Modify logging to have a Travis fold for each new env, rather than each individual subprocess run.

### Result
See https://travis-ci.org/pantsbuild/setup/jobs/508167593 for how logging looks now.