### PR TITLE
Add shellcheck.py script and improve ./pants with results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ linux_setup: &linux_setup
 
 matrix:
   include:
-    - name: "Linter and formatting check"
+    - name: "Lint ./pants script"
       <<: *linux_setup
       dist: xenial
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,18 @@ linux_setup: &linux_setup
 
 matrix:
   include:
+    - name: "Linter and formatting check"
+      <<: *linux_setup
+      dist: xenial
+      before_install:
+        - pyenv global 3.6.7
+      addons:
+        apt:
+          packages:
+            - shellcheck
+      script:
+        - ./build-support/shellcheck.py
+
     - name: "OSX 10.11 - El Capitan"
       <<: *osx_setup
       osx_image: xcode8.0

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -15,8 +15,8 @@ def main() -> None:
 
 def ensure_shellcheck_installed() -> None:
   if shutil.which("shellcheck") is None:
-    die("`shellcheck` not installed! You may download this through brew or apt. "
-        "See https://www.shellcheck.net.")
+    die("`shellcheck` not installed! You may download this through brew, apt, or yum. "
+        "See https://github.com/koalaman/shellcheck#installing.")
 
 
 def run_shellcheck() -> None:

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -15,8 +15,8 @@ def main() -> None:
 
 def ensure_shellcheck_installed() -> None:
   if shutil.which("shellcheck") is None:
-    die("`shellcheck` not installed! You may download this through brew, apt, or yum. "
-        "See https://github.com/koalaman/shellcheck#installing.")
+    die("`shellcheck` not installed! You may download this your operating system's package manager, "
+        "such as brew, apt, or yum. See https://github.com/koalaman/shellcheck#installing.")
 
 
 def run_shellcheck() -> None:

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import shutil
+import subprocess
+
+from common import die, green
+
+
+def main() -> None:
+  ensure_shellcheck_installed()
+  run_shellcheck()
+
+
+def ensure_shellcheck_installed() -> None:
+  if shutil.which("shellcheck") is None:
+    die("`shellcheck` not installed! You may download this through brew or apt. "
+        "See https://www.shellcheck.net.")
+
+
+def run_shellcheck() -> None:
+  command = ["shellcheck", "--shell=bash", "./pants"]
+  try:
+    subprocess.run(command, check=True)
+  except subprocess.CalledProcessError:
+    die("Please fix the above errors and run again.")
+  else:
+    green("./pants passed the shellcheck!")
+
+
+if __name__ == "__main__":
+  main()

--- a/pants
+++ b/pants
@@ -46,7 +46,7 @@ function tempdir {
 
 function get_exe_path_or_die {
   exe="$1"
-  if ! which "${exe}"; then
+  if ! command -v "${exe}"; then
     die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
   fi
 }
@@ -100,8 +100,8 @@ function bootstrap_venv {
       mkdir -p "${PANTS_BOOTSTRAP}"
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       cd "${staging_dir}"
-      curl -LO https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}
-      tar -xzf ${VENV_TARBALL}
+      curl -LO "https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}"
+      tar -xzf "${VENV_TARBALL}"
       ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest"
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
     ) 1>&2
@@ -138,7 +138,7 @@ function bootstrap_pants {
 }
 
 # Ensure we operate from the context of the ./pants buildroot.
-cd "$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd -P)"
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 python="$(determine_pants_runtime_python_version)"
 pants_dir="$(bootstrap_pants "${python}")"
 
@@ -147,6 +147,6 @@ pants_dir="$(bootstrap_pants "${python}")"
 # async-signal-safe syscalls after we fork a process that has already spawned threads.
 #
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
-export no_proxy=*
+export no_proxy='*'
 
 exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"


### PR DESCRIPTION
### Problem
The entire point of this repo is the `./pants` script, so we should be using as much CI as possible to ensure it works well. While we do now have `ci.py` to act as an integration test, we would benefit from a linter.

### Solution
Use `shellcheck`, which is the most used and recommended linter for Bash scripts. 

Specifically:
* Add new `shellcheck.py` script
* Add new CI shard that runs `shellcheck.py` to avoid regressions
* Fix issues discovered in `./pants`