### PR TITLE
Auto-generate pants.ini with pinned pants_version if file is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
           --skip-pantsd-tests
         - ./build-support/ci.py
           --pants-versions config
-          --python-versions unspecified 2.7 3.6
+          --python-versions unspecified 2.7 3.6 3.7
           --skip-pantsd-tests
         - ./build-support/test_pants_ini_autogen.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - ./build-support/ci.py
     --pants-versions config
     --python-versions unspecified 2.7 3.6 3.7
+  - ./build-support/test_pants_ini_autogen.py
 
 osx_setup: &osx_setup
   os: osx
@@ -92,6 +93,7 @@ matrix:
           --pants-versions config
           --python-versions unspecified 2.7 3.6
           --skip-pantsd-tests
+        - ./build-support/test_pants_ini_autogen.py
 
 
     - name: "OSX 10.13 - High Sierra"
@@ -114,6 +116,7 @@ matrix:
         - ./build-support/ci.py
           --pants-versions config
           --python-versions unspecified 2.7 3.6
+        - ./build-support/test_pants_ini_autogen.py
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -127,6 +130,7 @@ matrix:
         - ./build-support/ci.py
           --pants-versions config
           --python-versions unspecified 2.7 3.6
+        - ./build-support/test_pants_ini_autogen.py
 
 
     - name: "Ubuntu 16.04 - Xenial"

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -100,9 +100,9 @@ def temporarily_rewrite_config(updated_config: configparser.ConfigParser):
 
 @contextmanager
 def temporarily_remove_config():
-  original_config = read_config()
-  Path(PANTS_INI).unlink()
+  Path(PANTS_INI).rename("pants.ini.orig")
   try:
     yield
   finally:
-    write_config(original_config)
+    Path(PANTS_INI).unlink()
+    Path("pants.ini.orig").rename("pants.ini")

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -96,3 +96,13 @@ def temporarily_rewrite_config(updated_config: configparser.ConfigParser):
     yield
   finally:
     write_config(original_config)
+
+
+@contextmanager
+def temporarily_remove_config():
+  original_config = read_config()
+  Path(PANTS_INI).unlink()
+  try:
+    yield
+  finally:
+    write_config(original_config)

--- a/build-support/test_pants_ini_autogen.py
+++ b/build-support/test_pants_ini_autogen.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import configparser
+import subprocess
+from pathlib import Path
+
+from ci import PantsVersion, setup_pants_version
+from common import (CONFIG_GLOBAL_SECTION, PANTS_INI, die, read_config,
+                    temporarily_remove_config, travis_section)
+
+
+def main() -> None:
+  with travis_section("PantsIniAutoGen", "Testing auto-generation of pants.ini."):
+    with temporarily_remove_config():
+      subprocess.run(["./pants"], check=True)
+      assert_file_created()
+      config = read_config()
+      assert_pants_version_pinned_properly(config)
+
+
+def assert_file_created() -> None:
+  if not Path(PANTS_INI).is_file():
+    die("pants.ini not created!")
+
+
+def assert_pants_version_pinned_properly(config: configparser.ConfigParser) -> None:
+  if "pants_version" not in config[CONFIG_GLOBAL_SECTION]:
+    die("`pants_version` not pinned!")
+  pinned_pants_v = config[CONFIG_GLOBAL_SECTION]["pants_version"]
+  with setup_pants_version(PantsVersion.unspecified):
+    unconfigured_pants_v = subprocess.run(
+      ["./pants", "-V"], stdout=subprocess.PIPE, encoding="utf-8", check=True
+    ).stdout.strip()
+  if pinned_pants_v != unconfigured_pants_v:
+    die(f"The pinned `pants_version` ({pinned_pants_v}) does not match the value when "
+        f"leaving `pants_version` unspecified ({unconfigured_pants_v})")
+
+
+if __name__ == "__main__":
+  main()

--- a/build-support/test_pants_ini_autogen.py
+++ b/build-support/test_pants_ini_autogen.py
@@ -22,12 +22,12 @@ def main() -> None:
 
 def assert_file_created() -> None:
   if not Path(PANTS_INI).is_file():
-    die("pants.ini not created!")
+    die("pants.ini not created in the repo root.")
 
 
 def assert_pants_version_pinned_properly(config: configparser.ConfigParser) -> None:
   if "pants_version" not in config[CONFIG_GLOBAL_SECTION]:
-    die("`pants_version` not pinned!")
+    die("`pants_version` not pinned.")
   pinned_pants_v = config[CONFIG_GLOBAL_SECTION]["pants_version"]
   with setup_pants_version(PantsVersion.unspecified):
     unconfigured_pants_v = subprocess.run(
@@ -35,7 +35,7 @@ def assert_pants_version_pinned_properly(config: configparser.ConfigParser) -> N
     ).stdout.strip()
   if pinned_pants_v != unconfigured_pants_v:
     die(f"The pinned `pants_version` ({pinned_pants_v}) does not match the value when "
-        f"leaving `pants_version` unspecified ({unconfigured_pants_v})")
+        f"leaving `pants_version` unspecified ({unconfigured_pants_v}).")
 
 
 if __name__ == "__main__":

--- a/build-support/test_pants_ini_autogen.py
+++ b/build-support/test_pants_ini_autogen.py
@@ -2,6 +2,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+"""Test that auto-generation of pants.ini works as expected.
+
+Note this is a separate file from ci.py because we only want to test the auto-generation
+part of ./pants here, and leave it to ci.py to test the other behavior like correctly
+parsing values from pants.ini and that the virtual env actually works. """
+
 import configparser
 import subprocess
 from pathlib import Path

--- a/index.html
+++ b/index.html
@@ -4,31 +4,26 @@
   </head>
   <body>
     <p>
-    To setup pants in your repo:
+    To setup Pants in your repo:
     <pre>
       curl -L -O https://pantsbuild.github.io/setup/pants
       chmod +x pants
-      touch pants.ini
     </pre>
     The only requirement is that you have a python 2.7 interpreter somewhere on
     your PATH.
     </p>
     <p>
-    The first time you run the new <code>./pants</code> script it will install
-    the latest pants version and then run it.
-    On subsequent runs it will find the already installed pants and run it.
+    The first time you run the new <code>./pants</code> script, it will install
+    the latest Pants version and generate a config file <code>pants.ini</code>
+    for you. On subsequent runs, the script will find the already installed
+    Pants and run it.
     </p>
     <p>
-    To pin the pants version, add an entry like so to pants.ini:
+    If you would like to use Pants plugins published to PyPi, you can configure them as
+    follows in <code>pants.ini</code>:
     <pre>
       [GLOBAL]
-      pants_version: 1.5.0
-    </pre>
-    If you use pants plugins published to pypi you can configure them as
-    follows, also in pants.ini:
-    <pre>
-      [GLOBAL]
-      pants_version: 1.5.0
+      pants_version: 1.14.0
 
       plugins: [
           'pantsbuild.pants.contrib.go==%(pants_version)s',
@@ -40,9 +35,9 @@
     <p>
     NB: The formatting of the plugins list is important; all lines below the
     `plugins:` line must be indented by at least one white space to form logical
-    continuation lines.  This is standard for python ini files, see
+    continuation lines.  This is standard for Python ini files, see
     <a href="http://tools.ietf.org/html/rfc822.html#section-3.1">RFC #822</a>
-    section 3.1.1 for the full rules python uses to parse ini file entries.
+    section 3.1.1 for the full rules Python uses to parse ini file entries.
     </p>
   </body>
 </html>

--- a/pants
+++ b/pants
@@ -142,14 +142,14 @@ function bootstrap_pants {
 
 function create_pants_ini_if_missing {
   if [[ ! -f "pants.ini" ]]; then
-    log "pants.ini not detected in the repository root. Creating with sensible defaults."
+    log "Config file \`pants.ini\` not detected in the repository root. Creating with sensible defaults.\n"
     touch "pants.ini"
     echo "[GLOBAL]" >> "pants.ini"
     # Pin pants_version
     pants_version="$(./pants -V)"
-    log "Pinning \`pants_version\` to \`${pants_version}\`."
+    log "* Pinning \`pants_version\` to \`${pants_version}\`."
     echo "pants_version: ${pants_version}" >> "pants.ini"
-    green "pants.ini created. Please modify as desired!"
+    green "\npants.ini created. You may now run \`./pants\` normally."
     exit 0
   fi
 }

--- a/pants
+++ b/pants
@@ -147,9 +147,9 @@ function create_pants_ini_if_missing {
     echo "[GLOBAL]" >> "pants.ini"
     # Pin pants_version
     pants_version="$(./pants -V)"
-    log "* Pinning \`pants_version\` to \`${pants_version}\`."
+    log "* Pinning \`pants_version\` to the most recent stable release: ${pants_version}."
     echo "pants_version: ${pants_version}" >> "pants.ini"
-    green "\npants.ini created. You may now run \`./pants\` normally."
+    green "\n\`pants.ini\` created. You may now run \`./pants\` normally."
     exit 0
   fi
 }

--- a/pants
+++ b/pants
@@ -52,13 +52,14 @@ function get_exe_path_or_die {
 }
 
 function get_pants_ini_config_value {
+  if [[ ! -f "pants.ini" ]]; then
+    return 0
+  fi
   config_key="$1"
   valid_delimiters="[:=]"
   optional_space="[[:space:]]*"
   prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-  if [[ -f "pants.ini" ]]; then
-    sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
-  fi
+  sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
 }
 
 function get_python_major_minor_version {
@@ -141,17 +142,19 @@ function bootstrap_pants {
 }
 
 function create_pants_ini_if_missing {
-  if [[ ! -f "pants.ini" ]]; then
-    log "Config file \`pants.ini\` not detected in the repository root. Creating with sensible defaults.\n"
-    touch "pants.ini"
-    echo "[GLOBAL]" >> "pants.ini"
-    # Pin pants_version
-    pants_version="$(./pants -V)"
-    log "* Pinning \`pants_version\` to the most recent stable release: ${pants_version}."
-    echo "pants_version: ${pants_version}" >> "pants.ini"
-    green "\n\`pants.ini\` created. You may now run \`./pants\` normally."
-    exit 0
+  if [[ -f "pants.ini" ]]; then
+    return 0
   fi
+  log "Config file \`pants.ini\` not detected in the repository root. Creating with sensible defaults.\n"
+  touch "pants.ini"
+  pants_version="$(./pants -V)"
+  log "* Pinning \`pants_version\` to the most recent stable release: ${pants_version}."
+  cat <<EOF >> "pants.ini"
+[GLOBAL]
+pants_version: ${pants_version}
+EOF
+  green "\n\`pants.ini\` created. You may now run \`./pants\`."
+  exit 0
 }
 
 # Ensure we operate from the context of the ./pants buildroot.

--- a/pants
+++ b/pants
@@ -56,7 +56,9 @@ function get_pants_ini_config_value {
   valid_delimiters="[:=]"
   optional_space="[[:space:]]*"
   prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-  sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
+  if [[ -f "pants.ini" ]]; then
+    sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
+  fi
 }
 
 function get_python_major_minor_version {

--- a/pants
+++ b/pants
@@ -74,6 +74,7 @@ EOF
 # 2.) Grab pants version from pants.ini or default to latest.
 # 3.) Check for a venv via a naming/path convention and execute if found.
 # 4.) Otherwise create venv and re-exec self.
+# 5.) Check if pants.ini already exists. If not, create with sensible defaults then exit.
 #
 # After that pants itself will handle making sure any requested plugins
 # are installed and up to date.
@@ -137,10 +138,25 @@ function bootstrap_pants {
   echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
 }
 
+function create_pants_ini_if_missing {
+  if [[ ! -f "pants.ini" ]]; then
+    log "pants.ini not detected in the repository root. Creating with sensible defaults."
+    touch "pants.ini"
+    echo "[GLOBAL]" >> "pants.ini"
+    # Pin pants_version
+    pants_version="$(./pants -V)"
+    log "Pinning \`pants_version\` to \`${pants_version}\`."
+    echo "pants_version: ${pants_version}" >> "pants.ini"
+    green "pants.ini created. Please modify as desired!"
+    exit 0
+  fi
+}
+
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 python="$(determine_pants_runtime_python_version)"
 pants_dir="$(bootstrap_pants "${python}")"
+create_pants_ini_if_missing
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non

--- a/pants
+++ b/pants
@@ -52,7 +52,7 @@ function get_exe_path_or_die {
 }
 
 function get_pants_ini_config_value {
-  if [[ ! -f "pants.ini" ]]; then
+  if [[ ! -f 'pants.ini' ]]; then
     return 0
   fi
   config_key="$1"
@@ -141,11 +141,8 @@ function bootstrap_pants {
   echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
 }
 
-function create_pants_ini_if_missing {
-  if [[ -f "pants.ini" ]]; then
-    return 0
-  fi
-  log "Config file \`pants.ini\` not detected in the repository root. Creating with sensible defaults.\n"
+function autogen_pants_ini {
+  log "Config file \`pants.ini\` not detected in the repository root. Creating with sensible defaults:\n"
   touch "pants.ini"
   pants_version="$(./pants -V)"
   log "* Pinning \`pants_version\` to the most recent stable release: ${pants_version}."
@@ -154,14 +151,16 @@ function create_pants_ini_if_missing {
 pants_version: ${pants_version}
 EOF
   green "\n\`pants.ini\` created. You may now run \`./pants\`."
-  exit 0
 }
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 python="$(determine_pants_runtime_python_version)"
 pants_dir="$(bootstrap_pants "${python}")"
-create_pants_ini_if_missing
+if [[ ! -f 'pants.ini' ]]; then
+  autogen_pants_ini
+  exit 0
+fi
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non


### PR DESCRIPTION
### Problem
Our first-time [setup instructions](https://www.pantsbuild.org/install.html#recommended-installation) are harder than need be. Currently, before being able to do anything with Pants, you must:

1) curl `pants`
1) `chmod +x pants`
1) `touch pants.ini`
1) Copy and paste `[GLOBAL]` into the file.
1) Run `./pants -V` or decide you want to pin a different value.
1) Copy and paste that value into a new line `pants_version`.

Instead, we could simplify the instructions to:

1) curl `pants`
1) `chmod +x pants`
1) `./pants`
1) Inspect `pants.ini` to make sure you're okay with the defaults.

Simplifying the onboarding process should make it easier for us to retain first time users. There are a lot of new concepts they already have to learn, e.g. BUILD files, targets, and goals. The less overwhelming we can make this process, the better.

Refer to https://pantsbuild.slack.com/archives/CBNMV1LRH/p1552506655047900 for the original discussion around this idea.

#### Concern about creating `pants.ini` being a tutorial
While there is some value in creating `pants.ini` so that users see how the config works, we can still get this benefit via logging when we create it and then instructing them on the website to inspect the file and change the values if desired.

### Solution
* Add logic to check if `pants.ini` exists and create it if not.
* Modify `pants_ini_config_value` to work if `pants.ini` is missing.

#### Testing
Add a test file specifically dedicated to this feature that temporarily deletes our `pants.ini`, runs `./pants`, and inspects the results to confirm they're as expected.

This is a separate file, rather than being with `ci.py`, because they are testing different things. This solely is meant to test our auto-generation works, whereas `ci.py` is meant to test that we 1) bootstrap properly, 2) properly parse `pants_version` and `pants_runtime_python_version`, and 3) `./pants -V` and `./pants list ::` work with both pantsd on and off.

### Result
If you already have `pants.ini`, everything behaves the same.

If you don't, we'll create it and print this:

```
Config file `pants.ini` not detected in the repository root. Creating with sensible defaults:

* Pinning `pants_version` to the most recent stable release: 1.14.0.

`pants.ini` created. You may now run `./pants` normally.
```