### PR TITLE
Redirect to pantsbuild.org in README and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 This repository contains the bootstrap needed to get you up and running with pants.
 
-Follow the instructions here https://pantsbuild.github.io/setup/
+Follow the instructions at https://www.pantsbuild.org/install.

--- a/index.html
+++ b/index.html
@@ -1,11 +1,5 @@
 <html>
   <head>
-    <title>Pants Setup</title>
+    <meta http-equiv="refresh" content="0; url=https://www.pantsbuild.org/install">
   </head>
-  <body>
-    <p style="font-size:150%;">
-    Follow the instructions at <a href="https://www.pantsbuild.org/install">
-      https://www.pantsbuild.org/install</a> to setup Pants.
-    </p>
-  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,12 @@
 <html>
   <head>
+    <title>Pants Setup</title>
     <meta http-equiv="refresh" content="0; url=https://www.pantsbuild.org/install">
   </head>
+  <body>
+    <p style="font-size:150%;">
+    Follow the instructions at <a href="https://www.pantsbuild.org/install">
+      https://www.pantsbuild.org/install</a> to setup Pants.
+    </p>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,46 +3,9 @@
     <title>Pants Setup</title>
   </head>
   <body>
-    <p>
-    To setup pants in your repo:
-    <pre>
-      curl -L -O https://pantsbuild.github.io/setup/pants
-      chmod +x pants
-      touch pants.ini
-    </pre>
-    The only requirement is that you have a python 2.7 interpreter somewhere on
-    your PATH.
-    </p>
-    <p>
-    The first time you run the new <code>./pants</code> script it will install
-    the latest pants version and then run it.
-    On subsequent runs it will find the already installed pants and run it.
-    </p>
-    <p>
-    To pin the pants version, add an entry like so to pants.ini:
-    <pre>
-      [GLOBAL]
-      pants_version: 1.5.0
-    </pre>
-    If you use pants plugins published to pypi you can configure them as
-    follows, also in pants.ini:
-    <pre>
-      [GLOBAL]
-      pants_version: 1.5.0
-
-      plugins: [
-          'pantsbuild.pants.contrib.go==%(pants_version)s',
-          'pantsbuild.pants.contrib.scrooge==%(pants_version)s',
-        ]
-    </pre>
-    Pants will notice you changed your plugins and install them.
-    </p>
-    <p>
-    NB: The formatting of the plugins list is important; all lines below the
-    `plugins:` line must be indented by at least one white space to form logical
-    continuation lines.  This is standard for python ini files, see
-    <a href="http://tools.ietf.org/html/rfc822.html#section-3.1">RFC #822</a>
-    section 3.1.1 for the full rules python uses to parse ini file entries.
+    <p style="font-size:150%;">
+    Follow the instructions at <a href="https://www.pantsbuild.org/install">
+      https://www.pantsbuild.org/install</a> to setup Pants.
     </p>
   </body>
 </html>


### PR DESCRIPTION
We were duplicating the instructions. It would be better to point to the official website in the README and to automatically redirect with the site.