### PR TITLE
Allow for pants.ini to be missing

### DIFF
--- a/pants
+++ b/pants
@@ -52,6 +52,9 @@ function get_exe_path_or_die {
 }
 
 function get_pants_ini_config_value {
+  if [[ ! -f 'pants.ini' ]]; then
+    return 0
+  fi
   config_key="$1"
   valid_delimiters="[:=]"
   optional_space="[[:space:]]*"


### PR DESCRIPTION
### Problem
With us introducing the command `./pants generate-pants-ini` to simplify first time setup in https://github.com/pantsbuild/pants/pull/7448, we'll be able to in a followup to that PR make an additional simplification by having `./pants generate-pants-ini` not only populate `pants.ini` but to also create it.

So, when a user first curls the bootstrap script, we will no longer have them `touch pants.ini`.

However, without `pants.ini`, our parsing function will result in a sed error that the file cannot be found.

### Solution
Only try to parse `pants.ini` if it exists.