### PR TITLE
Fix ci.py messing up the formatting of pants.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ matrix:
           --skip-pantsd-tests
         - ./build-support/ci.py
           --pants-versions config
-          --python-versions unspecified 2.7 3.6
+          --python-versions unspecified 2.7 3.6 3.7
           --skip-pantsd-tests
 
 

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -90,9 +90,11 @@ def write_config(config: configparser.ConfigParser) -> None:
 
 @contextmanager
 def temporarily_rewrite_config(updated_config: configparser.ConfigParser):
-  original_config = read_config()
+  with open(PANTS_INI, "r") as f:
+    original_config = f.read()
   write_config(updated_config)
   try:
     yield
   finally:
-    write_config(original_config)
+    with open(PANTS_INI, "w") as f:
+      f.write(original_config)

--- a/pants.ini
+++ b/pants.ini
@@ -1,7 +1,7 @@
 [GLOBAL]
-pants_version : 1.15.0.dev4
-pants_runtime_python_version : 3.6
-plugins : [
-	'pantsbuild.pants.contrib.go==%(pants_version)s',
-	]
+pants_version: 1.15.0.dev4
+pants_runtime_python_version: 3.6
 
+plugins: [
+    'pantsbuild.pants.contrib.go==%(pants_version)s',
+  ]


### PR DESCRIPTION
### Problem
ConfigParser formats things strangely when writing to a file. So, any call to `ci.py` would result in our `pants.ini` permanently having bad formatting that conflicts with how we things at https://www.pantsbuild.org/install.html.

### Solution
With the context manager `temporarily_rewrite_config`, simply grab the original content and rewrite it back exactly, rather than using ConfigParser to write back.

Also add back testing of Python 3.7 to the OSX 10.12 shard, as it was unintentionally removed.