### PR TITLE
Determine default Python interpreter based on the pants_version being used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ env:
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
 script:
-  # TODO: Once 1.15.0 is cut, consolidate this back into one entry. Currently the
-  # python version cannot be specified when the pants_version is unspecified.
   - ./build-support/ci.py
-    --pants-versions unspecified
+    --pants-versions 1.14.0
     --python-versions unspecified
   - ./build-support/ci.py
-    --pants-versions config
-    --python-versions unspecified 2.7 3.6 3.7
+    --pants-versions unspecified 1.15.0
+    --python-versions unspecified 2.7 3.6
 
 cache:
   directories:
@@ -115,12 +113,12 @@ matrix:
       # https://github.com/pantsbuild/pants/issues/7323 are resolved.
       script:
         - ./build-support/ci.py
-          --pants-versions unspecified
+          --pants-versions 1.14.0
           --python-versions unspecified
           --skip-pantsd-tests
         - ./build-support/ci.py
-          --pants-versions config
-          --python-versions unspecified 2.7 3.6 3.7
+          --pants-versions unspecified 1.15.0
+          --python-versions unspecified 2.7 3.6
           --skip-pantsd-tests
 
 
@@ -141,13 +139,6 @@ matrix:
         - *pyenv_setup
         - *pyenv_install_py36
         - *pyenv_global_py36
-      script:
-        - ./build-support/ci.py
-          --pants-versions unspecified
-          --python-versions unspecified
-        - ./build-support/ci.py
-          --pants-versions config
-          --python-versions unspecified 2.7 3.6
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -156,14 +147,6 @@ matrix:
         - CACHE_NAME="linux.trusty"
       before_install:
         - pyenv global 2.7.14 3.6.3
-      script:
-        - ./build-support/ci.py
-          --pants-versions unspecified
-          --python-versions unspecified
-        - ./build-support/ci.py
-          --pants-versions config
-          --python-versions unspecified 2.7 3.6
-
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -17,6 +17,16 @@ from common import (CONFIG_GLOBAL_SECTION, banner, die, read_config,
 class PantsVersion(Enum):
   unspecified = "unspecified"
   config = "config"
+  # NB: we test all of the below Pants versions because they each represent
+  # a boundary in our Python 3 migration, as follows:
+  # * <= 1.14.0: Python 2.7
+  # * == 1.15.0: Python 2.7 or 3.6
+  # * == 1.16.0: Python 2.7, 3.6, or 3.7
+  # * >= 1.17.0: Python 3.6 or 3.7
+  one_fourteen = "1.14.0"
+  one_fifteen = "1.15.0"
+  one_sixteen = "1.16.0"
+  one_seventeen = "1.17.0"
 
   def __str__(self):
       return self.value
@@ -112,6 +122,9 @@ def setup_pants_version(test_pants_version: PantsVersion):
       die(f"You requested to use `{config_entry}` from pants.ini, but pants.ini does not include `{config_entry}`!")
     current_pants_version = updated_config[CONFIG_GLOBAL_SECTION][config_entry]
     banner(f"Using the `{config_entry}` set in pants.ini: `{current_pants_version}`.")
+  else:
+    updated_config[CONFIG_GLOBAL_SECTION][config_entry] = test_pants_version.value
+    banner(f"Temporarily rewriting `{config_entry}` to `{test_pants_version}`.")
   with temporarily_rewrite_config(updated_config):
     yield
   banner(f"Restoring original `{config_entry}` value in pants.ini.")

--- a/pants
+++ b/pants
@@ -90,7 +90,7 @@ function determine_default_python_exe {
     supported_python_versions=('3.6' '2.7')
     supported_message='2.7 or 3.6'
   else
-    pants_minor_version="$(echo ${pants_version} | cut -d '.' -f2)"
+    pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
     if [[ "${pants_minor_version}" -ge 17 ]]; then
       supported_python_versions=('3.6' '3.7' '3.8' '3')
       supported_message='3.6+'
@@ -108,7 +108,7 @@ function determine_default_python_exe {
   for version in "${supported_python_versions[@]}"; do
     command -v "python${version}" && return 0
   done
-  die "No valid valid Python interpreter found. Pants requires Python ${supported_message}."
+  die "No valid Python interpreter found. Pants requires Python ${supported_message}."
 }
 
 function determine_python_exe {

--- a/pants
+++ b/pants
@@ -93,8 +93,8 @@ function determine_default_python_exe {
     pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
     pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
     if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
-      supported_python_versions=('3.6' '2.7')
-      supported_message='2.7 or 3.6'
+      supported_python_versions=('2.7')
+      supported_message='2.7'
     elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
       supported_python_versions=('3.6' '2.7')
       supported_message='2.7 or 3.6'

--- a/pants
+++ b/pants
@@ -92,27 +92,21 @@ function determine_default_python_exe {
   else
     pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
     pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-    if [[ "${pants_major_version}" -eq 2 ]]; then
-      supported_python_versions=('3.9' '3.8' '3.7' '3.6')
+    if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
+      supported_python_versions=('3.6' '2.7')
+      supported_message='2.7 or 3.6'
+    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
+      supported_python_versions=('3.6' '2.7')
+      supported_message='2.7 or 3.6'
+    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 16 ]]; then
+      supported_python_versions=('3.6' '3.7' '2.7')
+      supported_message='2.7, 3.6, or 3.7'
+    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 17 ]]; then
+      supported_python_versions=('3.6' '3.7' '3.8' '3.9')
       supported_message='3.6+'
     else
-      if [[ "${pants_minor_version}" -gt 17 ]]; then
-        supported_python_versions=('3.9' '3.8' '3.7' '3.6')
-        supported_message='3.6+'
-      elif [[ "${pants_minor_version}" -eq 17 ]]; then
-        supported_python_versions=('3.6' '3.7' '3.8' '3.9')
-        supported_message='3.6+'
-      elif [[ "${pants_minor_version}" -eq 16 ]]; then
-        supported_python_versions=('3.6' '3.7' '2.7')
-        supported_message='2.7, 3.6, or 3.7'
-      elif [[ "${pants_minor_version}" -eq 15 ]]; then
-        supported_python_versions=('3.6' '2.7')
-        supported_message='2.7 or 3.6'
-      # <= 1.14.0 does not support Python 3.
-      else
-        supported_python_versions=('2.7')
-        supported_message='2.7'
-      fi
+      supported_python_versions=('3.9' '3.8' '3.7' '3.6')
+      supported_message='3.6+'
     fi
   fi
   for version in "${supported_python_versions[@]}"; do

--- a/pants
+++ b/pants
@@ -73,7 +73,8 @@ EOF
 
 # The high-level flow:
 # 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
-#     then reading from pants.ini, then defaulting to python3.6, and finally to python2.7.
+#     then reading from pants.ini, then determining the default based off of
+#     which Python versions the current `pants_version` supports.
 # 2.) Grab pants version from pants.ini or default to latest.
 # 3.) Check for a venv via a naming/path convention and execute if found.
 # 4.) Otherwise create venv and re-exec self.
@@ -81,7 +82,36 @@ EOF
 # After that pants itself will handle making sure any requested plugins
 # are installed and up to date.
 
-function determine_pants_runtime_python_version {
+function determine_default_python_exe {
+  pants_version="$(get_pants_ini_config_value 'pants_version')"
+  # If `pants_version` not pinned in `pants.ini`, default to what the most
+  # recent stable release supports.
+  if [[ -z "${pants_version}" ]]; then
+    supported_python_versions=('3.6' '2.7')
+    supported_message='2.7 or 3.6'
+  else
+    pants_minor_version="$(echo ${pants_version} | cut -d '.' -f2)"
+    if [[ "${pants_minor_version}" -ge 17 ]]; then
+      supported_python_versions=('3.6' '3.7' '3.8' '3')
+      supported_message='3.6+'
+    elif [[ "${pants_minor_version}" -eq 16 ]]; then
+      supported_python_versions=('3.6' '3.7' '2.7')
+      supported_message='2.7, 3.6, or 3.7'
+    elif [[ "${pants_minor_version}" -eq 15 ]]; then
+      supported_python_versions=('3.6' '2.7')
+      supported_message='2.7 or 3.6'
+    else
+      supported_python_versions=('2.7')
+      supported_message='2.7'
+    fi
+  fi
+  for version in "${supported_python_versions[@]}"; do
+    command -v "python${version}" && return 0
+  done
+  die "No valid valid Python interpreter found. Pants requires Python ${supported_message}."
+}
+
+function determine_python_exe {
   if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
     python_bin_name="${PYTHON_BIN_NAME}"
   else
@@ -89,10 +119,7 @@ function determine_pants_runtime_python_version {
     if [[ -n "${interpreter_version}" ]]; then
       python_bin_name="python${interpreter_version}"
     else
-      python_bin_name="$(
-        command -v "python3.6" \
-        || command -v "python2.7" \
-        || die "No valid Python interpreter found. Pants requires Python 2.7 or 3.6.")"
+      python_bin_name="$(determine_default_python_exe)"
     fi
   fi
   get_exe_path_or_die "${python_bin_name}"
@@ -146,7 +173,7 @@ function bootstrap_pants {
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-python="$(determine_pants_runtime_python_version)"
+python="$(determine_python_exe)"
 pants_dir="$(bootstrap_pants "${python}")"
 
 

--- a/pants
+++ b/pants
@@ -118,7 +118,7 @@ function determine_default_python_exe {
   for version in "${supported_python_versions[@]}"; do
     command -v "python${version}" && return 0
   done
-  die "No valid Python interpreter found. Pants requires Python ${supported_message}."
+  die "No valid Python interpreter found. For this Pants version, Pants requires Python ${supported_message}."
 }
 
 function determine_python_exe {

--- a/pants
+++ b/pants
@@ -93,10 +93,13 @@ function determine_default_python_exe {
     pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
     pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
     if [[ "${pants_major_version}" -eq 2 ]]; then
-      supported_python_versions=('3.6' '3.7' '3.8' '3.9')
+      supported_python_versions=('3.9' '3.8' '3.7' '3.6')
       supported_message='3.6+'
     else
-      if [[ "${pants_minor_version}" -ge 17 ]]; then
+      if [[ "${pants_minor_version}" -gt 17 ]]; then
+        supported_python_versions=('3.9' '3.8' '3.7' '3.6')
+        supported_message='3.6+'
+      elif [[ "${pants_minor_version}" -eq 17 ]]; then
         supported_python_versions=('3.6' '3.7' '3.8' '3.9')
         supported_message='3.6+'
       elif [[ "${pants_minor_version}" -eq 16 ]]; then

--- a/pants
+++ b/pants
@@ -90,19 +90,26 @@ function determine_default_python_exe {
     supported_python_versions=('3.6' '2.7')
     supported_message='2.7 or 3.6'
   else
+    pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
     pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-    if [[ "${pants_minor_version}" -ge 17 ]]; then
-      supported_python_versions=('3.6' '3.7' '3.8' '3')
+    if [[ "${pants_major_version}" -eq 2 ]]; then
+      supported_python_versions=('3.6' '3.7' '3.8' '3.9')
       supported_message='3.6+'
-    elif [[ "${pants_minor_version}" -eq 16 ]]; then
-      supported_python_versions=('3.6' '3.7' '2.7')
-      supported_message='2.7, 3.6, or 3.7'
-    elif [[ "${pants_minor_version}" -eq 15 ]]; then
-      supported_python_versions=('3.6' '2.7')
-      supported_message='2.7 or 3.6'
     else
-      supported_python_versions=('2.7')
-      supported_message='2.7'
+      if [[ "${pants_minor_version}" -ge 17 ]]; then
+        supported_python_versions=('3.6' '3.7' '3.8' '3.9')
+        supported_message='3.6+'
+      elif [[ "${pants_minor_version}" -eq 16 ]]; then
+        supported_python_versions=('3.6' '3.7' '2.7')
+        supported_message='2.7, 3.6, or 3.7'
+      elif [[ "${pants_minor_version}" -eq 15 ]]; then
+        supported_python_versions=('3.6' '2.7')
+        supported_message='2.7 or 3.6'
+      # <= 1.14.0 does not support Python 3.
+      else
+        supported_python_versions=('2.7')
+        supported_message='2.7'
+      fi
     fi
   fi
   for version in "${supported_python_versions[@]}"; do

--- a/pants
+++ b/pants
@@ -73,8 +73,7 @@ EOF
 
 # The high-level flow:
 # 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
-#     then reading from pants.ini, then defaulting to python3.6, then python3.7,
-#     and finally python2.7.
+#     then reading from pants.ini, then defaulting to python3.6, and finally to python2.7.
 # 2.) Grab pants version from pants.ini or default to latest.
 # 3.) Check for a venv via a naming/path convention and execute if found.
 # 4.) Otherwise create venv and re-exec self.
@@ -92,9 +91,8 @@ function determine_pants_runtime_python_version {
     else
       python_bin_name="$(
         command -v "python3.6" \
-        || command -v "python3.7" \
         || command -v "python2.7" \
-        || die "No valid Python interpreter found. Pants requires Python 2.7, 3.6, or 3.7.")"
+        || die "No valid Python interpreter found. Pants requires Python 2.7 or 3.6.")"
     fi
   fi
   get_exe_path_or_die "${python_bin_name}"

--- a/pants
+++ b/pants
@@ -73,7 +73,8 @@ EOF
 
 # The high-level flow:
 # 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
-#     then reading from pants.ini, then defaulting to `python2.7`.
+#     then reading from pants.ini, then defaulting to python3.6, then python3.7,
+#     and finally python2.7.
 # 2.) Grab pants version from pants.ini or default to latest.
 # 3.) Check for a venv via a naming/path convention and execute if found.
 # 4.) Otherwise create venv and re-exec self.
@@ -86,10 +87,15 @@ function determine_pants_runtime_python_version {
     python_bin_name="${PYTHON_BIN_NAME}"
   else
     interpreter_version="$(get_pants_ini_config_value 'pants_runtime_python_version')"
-    if [[ -z "${interpreter_version}" ]]; then
-      interpreter_version='2.7'
+    if [[ -n "${interpreter_version}" ]]; then
+      python_bin_name="python${interpreter_version}"
+    else
+      python_bin_name="$(
+        command -v "python3.6" \
+        || command -v "python3.7" \
+        || command -v "python2.7" \
+        || die "No valid Python interpreter found. Pants requires Python 2.7, 3.6, or 3.7.")"
     fi
-    python_bin_name="python${interpreter_version}"
   fi
   get_exe_path_or_die "${python_bin_name}"
 }

--- a/pants.ini
+++ b/pants.ini
@@ -1,6 +1,5 @@
 [GLOBAL]
-pants_version: 1.15.0.dev4
-pants_runtime_python_version: 3.6
+pants_version: 1.15.0
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',


### PR DESCRIPTION
### Problem
Now that using Python 2.7 is ~deprecated and support will be removed soon, we need to stop defaulting to 2.7. 

Defaulting to Python 3 will make for a less stark transition. Specifically, users will be able to leave out `pants_runtime_python_version` from their `pants.ini`, which is good because we will deprecate this option once we drop Py2.

However, we do not want to break backwards compatibility. A user should be able to downgrade to 1.14.0 without issues.

### Solution
Determine which `pants_version` the user has pinned, and set the default interpreter from there, as follows:

* `<= 1.14.0`: Python 2.7
* `== 1.15.0`: Python 3.6->2.7
* `== 1.16.0`: Python 3.6->3.7->2.7
* `== 1.17.0`: Python 3.6->3.7->3.8->3.9
* `> 1.17.0`: Python 3.9->3.8->3.7->3.6

Notably, we first default to Python 3 and only fall back to Python 2 when necessary. We do this because we want most people using Python 3 so that we can completely stress test it before dropping Python 2.

For versions `> 1.17.0`, we default to using the max interpreter possible and only fall back to 3.6 as a last resort. This allows us to make no assumptions about Pants supporting 3.6 in the future.

If the user has not pinned `pants_version`, such as happens with first time users, we use the default interpreters for the current major release. With 1.15.0, this means we would use 3.6 or 2.7. Until 1.18.0 is released and our migration is stabilized, we will update the default case in the `./pants` script to match that new release. This should only impact new users before they run the `./pants generate-pants-ini` command.

We also avoid the ambiguous `python3` bin name to avoid accidentally trying to use Python 3.5, for example.
