### PR TITLE
Refactor .travis.yml by extracting install_python_for_ci.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
-    - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
 script:
@@ -28,28 +27,6 @@ cache:
   directories:
     - ${PYENV_ROOT}
 
-pyenv_setup: &pyenv_setup >
-  if [[ ! -x "${PYENV_BIN}" ]]; then
-    rm -rf "${PYENV_ROOT}"
-    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
-  fi
-
-pyenv_install_py36: &pyenv_install_py36 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY36_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
-  fi
-
-pyenv_install_py37: &pyenv_install_py37 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY37_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
-  fi
-
-pyenv_global_py36: &pyenv_global_py36 >
-  "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
-
-pyenv_global_py36_py37: &pyenv_global_py36_py37 >
-  "${PYENV_BIN}" global "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
-
 osx_setup: &osx_setup
   os: osx
   language: generic
@@ -65,10 +42,7 @@ osx_setup: &osx_setup
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - *pyenv_setup
-    - *pyenv_install_py36
-    - *pyenv_install_py37
-    - *pyenv_global_py36_py37
+    - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -138,9 +112,7 @@ matrix:
       env:
         - CACHE_NAME="linux.precise"
       before_install:
-        - *pyenv_setup
-        - *pyenv_install_py36
-        - *pyenv_global_py36
+        - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
       script:
         - ./build-support/ci.py
           --pants-versions unspecified

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -1,0 +1,59 @@
+CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
+
+TRAVIS_FOLD_STATE="/tmp/.travis_fold_current"
+
+CLEAR_LINE="\x1b[K"
+COLOR_BLUE="\x1b[34m"
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_RESET="\x1b[0m"
+
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "\n${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "\n${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+# Initialization for elapsed()
+: ${elapsed_start_time:=$(date +'%s')}
+export elapsed_start_time
+
+function elapsed() {
+  now=$(date '+%s')
+  elapsed_secs=$(( $now - $elapsed_start_time ))
+  echo $elapsed_secs | awk '{printf "%02d:%02d\n",int($1/60), int($1%60)}'
+}
+
+function banner() {
+  echo -e "${COLOR_BLUE}[=== $(elapsed) $* ===]${COLOR_RESET}"
+}
+
+function travis_fold() {
+  local action=$1
+  local slug=$2
+  # Use the line clear terminal escape code to prevent the travis_fold lines from
+  # showing up if e.g. a user is running the calling script.
+  echo -en "travis_fold:${action}:${slug}\r${CLEAR_LINE}"
+}
+
+function start_travis_section() {
+  local slug="$1"
+  travis_fold start "${slug}"
+  /bin/echo -n "${slug}" > "${TRAVIS_FOLD_STATE}"
+  shift
+  local section="$*"
+  banner "${section}"
+}
+
+function end_travis_section() {
+  travis_fold end "$(cat ${TRAVIS_FOLD_STATE})"
+  rm -f "${TRAVIS_FOLD_STATE}"
+}

--- a/build-support/install_python_for_ci.sh
+++ b/build-support/install_python_for_ci.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Install the requested Python version(s) through Pyenv.
+
+# While Travis ships with Pyenv on both OSX and Linux, the Pyenv version is too
+# outdated on several images for installing modern Python versions like 3.7. To
+# get around this, we directly clone the Pyenv repo.
+
+source build-support/common.sh
+
+PYTHON_VERSIONS="$@"
+
+if [[ -z "${PYENV_ROOT:+''}" ]]; then
+  die "Caller of the script must set the env var PYENV_ROOT."
+fi
+PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
+
+# We first check if Pyenv is already installed thanks to Travis's cache.
+if [[ ! -x "${PYENV_BIN}" ]]; then
+  rm -rf "${PYENV_ROOT}"
+  git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
+fi
+
+for python_version in "${PYTHON_VERSIONS[@]}"; do
+  if [[ ! -d ${PYENV_ROOT}/versions/"${python_version}" ]]; then
+    "${PYENV_BIN}" install "${python_version}"
+  fi
+done
+
+"${PYENV_BIN}" global "${PYTHON_VERSIONS[@]}"

--- a/build-support/install_python_for_ci.sh
+++ b/build-support/install_python_for_ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 # Install the requested Python version(s) through Pyenv.
 
@@ -21,6 +21,8 @@ PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
 if [[ ! -x "${PYENV_BIN}" ]]; then
   rm -rf "${PYENV_ROOT}"
   git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
+else
+  ls "${PYENV_ROOT}"
 fi
 
 for python_version in "${PYTHON_VERSIONS[@]}"; do

--- a/build-support/install_python_for_ci.sh
+++ b/build-support/install_python_for_ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 # Install the requested Python version(s) through Pyenv.
 
@@ -10,7 +10,7 @@ set -euox pipefail
 
 source build-support/common.sh
 
-PYTHON_VERSIONS="$@"
+PYTHON_VERSIONS=("$@")
 
 if [[ -z "${PYENV_ROOT:+''}" ]]; then
   die "Caller of the script must set the env var PYENV_ROOT."
@@ -21,8 +21,6 @@ PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
 if [[ ! -x "${PYENV_BIN}" ]]; then
   rm -rf "${PYENV_ROOT}"
   git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
-else
-  ls "${PYENV_ROOT}"
 fi
 
 for python_version in "${PYTHON_VERSIONS[@]}"; do


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/7470, we came up with a better design for interfacing with our git cloned version of Pyenv. By extracting out a script, we keep `.travis.yml` more focused and are able to improve the robustness of Pyenv-related code, such as adding comments.