### PR TITLE
Dynamically determine the Pants version when not specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,14 @@ test_1_16_without_py37: &test_1_16_without_py37 >
   --pants-versions config
   --python-versions unspecified 2.7 3.6
 
-test_unspecified: &test_unspecified >
-  ./build-support/ci.py
-  --pants-versions unspecified
-  --python-versions unspecified 2.7 3.6
+test_first_time_install: &test_first_time_install >
+  ./build-support/test_first_time_install.py
 
 script:
   - *test_1_14
   - *test_1_15
   - *test_1_16
-  - *test_unspecified
+  - *test_first_time_install
 
 cache:
   directories:
@@ -129,7 +127,7 @@ matrix:
         - *test_1_14
         - *test_1_15
         - *test_1_16_without_py37
-        - *test_unspecified
+        - *test_first_time_install
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -142,7 +140,7 @@ matrix:
         - *test_1_14
         - *test_1_15
         - *test_1_16_without_py37
-        - *test_unspecified
+        - *test_first_time_install
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -15,7 +15,6 @@ from common import (CONFIG_GLOBAL_SECTION, banner, die, read_config,
 
 
 class PantsVersion(Enum):
-  unspecified = "unspecified"
   config = "config"
   # NB: we test all of the below Pants versions because they each represent
   # a boundary in our Python 3 migration, as follows:
@@ -110,15 +109,10 @@ def run_tests(*, skip_pantsd_tests: bool) -> None:
 
 @contextmanager
 def setup_pants_version(test_pants_version: PantsVersion):
-  """Modify pants.ini to allow the pants version to be unspecified or keep what was originally there."""
+  """Modify pants.ini to allow the pants version to be a specified version or to keep what was originally there."""
   updated_config = read_config()
   config_entry = "pants_version"
-  if test_pants_version == PantsVersion.unspecified:
-    updated_config.remove_option(CONFIG_GLOBAL_SECTION, config_entry)
-    # NB: We also remove plugins as they refer to the pants_version.
-    updated_config.remove_option(CONFIG_GLOBAL_SECTION, "plugins")
-    banner(f"Temporarily removing `{config_entry}` from pants.ini.")
-  elif test_pants_version == PantsVersion.config:
+  if test_pants_version == PantsVersion.config:
     if config_entry not in updated_config[CONFIG_GLOBAL_SECTION]:
       die(f"You requested to use `{config_entry}` from pants.ini, but pants.ini does not include `{config_entry}`!")
     current_pants_version = updated_config[CONFIG_GLOBAL_SECTION][config_entry]

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -87,19 +87,20 @@ def copy_pants_into_tmpdir():
 
 
 @contextmanager
-def point_pants_home_to_dir(dir: str):
-  original_env = os.environ.copy()
-  os.environ["PANTS_HOME"] = dir
-  try:
-    yield
-  finally:
-    os.environ = original_env
+def set_pants_cache_to_tmpdir():
+  with tempfile.TemporaryDirectory() as tmpdir:
+    original_env = os.environ.copy()
+    os.environ["PANTS_HOME"] = tmpdir
+    try:
+      yield
+    finally:
+      os.environ = original_env
 
 
 @contextmanager
 def setup_pants_in_tmpdir():
-  with copy_pants_into_tmpdir() as tmpdir, point_pants_home_to_dir(tmpdir):
-    yield tmpdir
+  with set_pants_cache_to_tmpdir(), copy_pants_into_tmpdir() as buildroot_tmpdir:
+    yield buildroot_tmpdir
 
 # --------------------------------------------------------
 # Rewrite pants.ini

--- a/build-support/test_first_time_install.py
+++ b/build-support/test_first_time_install.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Test that the first time installation flow described by
+https://www.pantsbuild.org/install.html#recommended-installation works as expected.
+
+Note that this does not test the result of `./pants generate-pants-ini`, because that
+is already tested by Pants at
+https://github.com/pantsbuild/pants/blob/master/tests/python/pants_test/core_tasks/test_generate_pants_ini.py."""
+
+import subprocess
+import unittest
+
+from common import setup_pants_in_tmpdir, travis_section
+
+
+class TestFirstTimeInstall(unittest.TestCase):
+
+  def test_venv_name_uses_most_recent_stable_release(self) -> None:
+    with setup_pants_in_tmpdir() as tmpdir:
+      completed_process = subprocess.run(
+        ["./pants", "--version"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        cwd=tmpdir
+      )
+      # Pip will resolve the most recent stable release, which will be the output of
+      # `./pants --version`.
+      downloaded_version = completed_process.stdout[-2]
+      virtual_env_created_log_entry = next(
+        line for line in completed_process.stderr.split("\n")
+        if "created" in line and "bootstrap" in line
+      )
+      self.assertIn(downloaded_version, virtual_env_created_log_entry)
+
+  def test_only_bootstraps_the_first_time(self) -> None:
+    with setup_pants_in_tmpdir() as tmpdir:
+      first_run_pants_script_logging = subprocess.run(
+        ["./pants", "--version"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        cwd=tmpdir
+      ).stderr
+      self.assertTrue(first_run_pants_script_logging)
+      second_run_pants_script_logging = subprocess.run(
+        ["./pants", "--version"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        cwd=tmpdir
+      ).stderr
+      self.assertFalse(second_run_pants_script_logging)
+
+if __name__ == "__main__":
+  with travis_section("PantsFirstTimeInstall", "Testing first time install."):
+    unittest.main()

--- a/build-support/test_first_time_install.py
+++ b/build-support/test_first_time_install.py
@@ -9,6 +9,7 @@ Note that this does not test the result of `./pants generate-pants-ini`, because
 is already tested by Pants at
 https://github.com/pantsbuild/pants/blob/master/tests/python/pants_test/core_tasks/test_generate_pants_ini.py."""
 
+import re
 import subprocess
 import unittest
 
@@ -32,7 +33,7 @@ class TestFirstTimeInstall(unittest.TestCase):
       downloaded_version = completed_process.stdout[-2]
       virtual_env_created_log_entry = next(
         line for line in completed_process.stderr.split("\n")
-        if "created" in line and "bootstrap" in line
+        if re.search(r"virtual environment successfully created at .*/bootstrap/.*_py", line)
       )
       self.assertIn(downloaded_version, virtual_env_created_log_entry)
 

--- a/build-support/test_first_time_install.py
+++ b/build-support/test_first_time_install.py
@@ -46,6 +46,7 @@ class TestFirstTimeInstall(unittest.TestCase):
         encoding="utf-8",
         cwd=tmpdir
       ).stderr
+      # Check that stderr is truthy, i.e. there is output.
       self.assertTrue(first_run_pants_script_logging)
       second_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
@@ -55,6 +56,7 @@ class TestFirstTimeInstall(unittest.TestCase):
         encoding="utf-8",
         cwd=tmpdir
       ).stderr
+      # Check that stderr is falsy, i.e. there is no output.
       self.assertFalse(second_run_pants_script_logging)
 
 if __name__ == "__main__":

--- a/build-support/test_first_time_install.py
+++ b/build-support/test_first_time_install.py
@@ -30,12 +30,11 @@ class TestFirstTimeInstall(unittest.TestCase):
       )
       # Pip will resolve the most recent stable release, which will be the output of
       # `./pants --version`.
-      downloaded_version = completed_process.stdout[-2]
-      virtual_env_created_log_entry = next(
-        line for line in completed_process.stderr.split("\n")
-        if re.search(r"virtual environment successfully created at .*/bootstrap/.*_py", line)
-      )
-      self.assertIn(downloaded_version, virtual_env_created_log_entry)
+      downloaded_version = completed_process.stdout.strip()
+      self.assertTrue(re.search(
+        fr"virtual environment successfully created at .*/bootstrap.*/{downloaded_version}_py",
+        completed_process.stderr, flags=re.MULTILINE
+      ))
 
   def test_only_bootstraps_the_first_time(self) -> None:
     with setup_pants_in_tmpdir() as tmpdir:

--- a/pants
+++ b/pants
@@ -72,42 +72,46 @@ EOF
 }
 
 # The high-level flow:
-# 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
+# 1.) Resolve the Pants version from pants.ini or from the latest stable
+#     release to PyPi.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON,
 #     then reading from pants.ini, then determining the default based off of
-#     which Python versions the current `pants_version` supports.
-# 2.) Grab pants version from pants.ini or default to latest.
+#     which Python versions the Pants version supports.
 # 3.) Check for a venv via a naming/path convention and execute if found.
 # 4.) Otherwise create venv and re-exec self.
 #
-# After that pants itself will handle making sure any requested plugins
+# After that, Pants itself will handle making sure any requested plugins
 # are installed and up to date.
 
-function determine_default_python_exe {
+function determine_pants_version {
   pants_version="$(get_pants_ini_config_value 'pants_version')"
-  # If `pants_version` not pinned in `pants.ini`, default to what the most
-  # recent stable release supports.
-  if [[ -z "${pants_version}" ]]; then
+  if [[ -n "${pants_version}" ]]; then
+    echo "${pants_version}"
+  else
+    curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
+      python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])"
+  fi
+}
+
+function determine_default_python_exe {
+  pants_version="$1"
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
+    supported_python_versions=('2.7')
+    supported_message='2.7'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
     supported_python_versions=('3.6' '2.7')
     supported_message='2.7 or 3.6'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 16 ]]; then
+    supported_python_versions=('3.6' '3.7' '2.7')
+    supported_message='2.7, 3.6, or 3.7'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 17 ]]; then
+    supported_python_versions=('3.6' '3.7' '3.8' '3.9')
+    supported_message='3.6+'
   else
-    pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
-    pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-    if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
-      supported_python_versions=('2.7')
-      supported_message='2.7'
-    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
-      supported_python_versions=('3.6' '2.7')
-      supported_message='2.7 or 3.6'
-    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 16 ]]; then
-      supported_python_versions=('3.6' '3.7' '2.7')
-      supported_message='2.7, 3.6, or 3.7'
-    elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 17 ]]; then
-      supported_python_versions=('3.6' '3.7' '3.8' '3.9')
-      supported_message='3.6+'
-    else
-      supported_python_versions=('3.9' '3.8' '3.7' '3.6')
-      supported_message='3.6+'
-    fi
+    supported_python_versions=('3.9' '3.8' '3.7' '3.6')
+    supported_message='3.6+'
   fi
   for version in "${supported_python_versions[@]}"; do
     command -v "python${version}" && return 0
@@ -116,6 +120,7 @@ function determine_default_python_exe {
 }
 
 function determine_python_exe {
+  pants_version="$1"
   if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
     python_bin_name="${PYTHON_BIN_NAME}"
   else
@@ -123,7 +128,7 @@ function determine_python_exe {
     if [[ -n "${interpreter_version}" ]]; then
       python_bin_name="python${interpreter_version}"
     else
-      python_bin_name="$(determine_default_python_exe)"
+      python_bin_name="$(determine_default_python_exe "${pants_version}")"
     fi
   fi
   get_exe_path_or_die "${python_bin_name}"
@@ -148,15 +153,10 @@ function bootstrap_venv {
 }
 
 function bootstrap_pants {
-  python="$1"
-  pants_requirement="pantsbuild.pants"
-  pants_version="$(get_pants_ini_config_value 'pants_version')"
-  if [[ -n "${pants_version}" ]]; then
-    pants_requirement="${pants_requirement}==${pants_version}"
-  else
-    pants_version="unspecified"
-  fi
+  pants_version="$1"
+  python="$2"
 
+  pants_requirement="pantsbuild.pants==${pants_version}"
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
   target_folder_name="${pants_version}_py${python_major_minor_version}"
 
@@ -177,8 +177,9 @@ function bootstrap_pants {
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-python="$(determine_python_exe)"
-pants_dir="$(bootstrap_pants "${python}")"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 
 
 # We set the env var no_proxy to '*', to work around an issue with urllib using non

--- a/pants
+++ b/pants
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # =============================== NOTE ===============================

--- a/pants
+++ b/pants
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # =============================== NOTE ===============================
-# This pants bootstrap script comes from the pantsbuild/setup
+# This ./pants bootstrap script comes from the pantsbuild/setup
 # project and is intended to be checked into your code repository so
 # that any developer can check out your code and be building it with
-# pants with no prior setup needed.
+# Pants with no prior setup needed.
 #
-# You can learn more here: https://pantsbuild.github.io/setup
+# You can learn more here: https://www.pantsbuild.org/install.html
 # ====================================================================
 
 set -eou pipefail
@@ -73,12 +73,14 @@ EOF
 
 # The high-level flow:
 # 1.) Resolve the Pants version from pants.ini or from the latest stable
-#     release to PyPi.
+#     release to PyPi, so that we know what to name the venv folder and which
+#     Python versions we can use.
 # 2.) Resolve the Python interpreter, first reading from the env var $PYTHON,
 #     then reading from pants.ini, then determining the default based off of
 #     which Python versions the Pants version supports.
-# 3.) Check for a venv via a naming/path convention and execute if found.
-# 4.) Otherwise create venv and re-exec self.
+# 3.) Check if the venv (virtual environment) already exists via a naming/path convention,
+#     and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
 #
 # After that, Pants itself will handle making sure any requested plugins
 # are installed and up to date.


### PR DESCRIPTION
### Problem
When following our install guide https://www.pantsbuild.org/install.html#recommended-installation, we end up bootstrapping *two* virtual environments and logging this to the user, which is confusing for your very first interaction with Pants.

This is because the script names the venv folder as `unspecified_py*` when `pants.ini` does not have a version pinned: https://github.com/pantsbuild/setup/blob/8fca2f4a51ddc65c931d4aba4ec3fbc1acf27234/pants#L154-L158.

### Solution
PyPi has a JSON API that we can ping to determine dynamically what the most recent stable release is. This is the same version `pip` will resolve to, so we simply name the venv folder this.

This also allows us to change our execution flow, so that we first determine the Pants version and _then_ determine the Python version, rather than the reverse. The benefit here is that the Python function solely depends on the Pants version, as of https://github.com/pantsbuild/setup/pull/49, and now the execution flow reflects this properly.

#### Testing
We add tests to ensure this all works.

In doing so, we add a new infrastructure for hermitic tests. Rather than acting directly on this repo's `pants.ini`, we use temporary directories to create a new, clean environment every run. This infrastructure will be used to refactor and improve the rest of this repo's tests in followup PRs.

### Result
If the `pants_version` is left off of `pants.ini`, Pants will setup the venv folder to use the most recent stable release.