### PR TITLE
Test Python 37 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,17 @@ env:
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
 script:
-  - ./build-support/ci.py
+  - &test_1_14 >
+    ./build-support/ci.py
     --pants-versions 1.14.0
     --python-versions unspecified
-  - ./build-support/ci.py
+  - &test_1_15_and_unspecified >
+    ./build-support/ci.py
     --pants-versions unspecified 1.15.0
     --python-versions unspecified 2.7 3.6
+  - ./build-support/ci.py
+    --pants-versions config
+    --python-versions unspecified 2.7 3.6 3.7
 
 cache:
   directories:
@@ -94,6 +99,10 @@ matrix:
           --pants-versions unspecified 1.15.0
           --python-versions unspecified 2.7 3.6
           --skip-pantsd-tests
+        - ./build-support/ci.py
+          --pants-versions config
+          --python-versions unspecified 2.7 3.6 3.7
+          --skip-pantsd-tests
 
 
     - name: "OSX 10.13 - High Sierra"
@@ -111,6 +120,9 @@ matrix:
         - CACHE_NAME="linux.precise"
       before_install:
         - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+      script:
+        - *test_1_14
+        - *test_1_15_and_unspecified
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -119,6 +131,9 @@ matrix:
         - CACHE_NAME="linux.trusty"
       before_install:
         - pyenv global 2.7.14 3.6.3
+      script:
+        - *test_1_14
+        - *test_1_15_and_unspecified
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,36 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
+test_1_14: &test_1_14 >
+  ./build-support/ci.py
+  --pants-versions 1.14.0
+  --python-versions unspecified
+
+test_1_15: &test_1_15 >
+  ./build-support/ci.py
+  --pants-versions 1.15.0
+  --python-versions unspecified 2.7 3.6
+
+test_1_16: &test_1_16 >
+  ./build-support/ci.py
+  --pants-versions config
+  --python-versions unspecified 2.7 3.6 3.7
+
+test_1_16_without_py37: &test_1_16_without_py37 >
+  ./build-support/ci.py
+  --pants-versions config
+  --python-versions unspecified 2.7 3.6
+
+test_unspecified: &test_unspecified >
+  ./build-support/ci.py
+  --pants-versions unspecified
+  --python-versions unspecified 2.7 3.6
+
 script:
-  - &test_1_14 >
-    ./build-support/ci.py
-    --pants-versions 1.14.0
-    --python-versions unspecified
-  - &test_1_15_and_unspecified >
-    ./build-support/ci.py
-    --pants-versions unspecified 1.15.0
-    --python-versions unspecified 2.7 3.6
-  - ./build-support/ci.py
-    --pants-versions config
-    --python-versions unspecified 2.7 3.6 3.7
+  - *test_1_14
+  - *test_1_15
+  - *test_1_16
+  - *test_unspecified
 
 cache:
   directories:
@@ -122,7 +140,9 @@ matrix:
         - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
       script:
         - *test_1_14
-        - *test_1_15_and_unspecified
+        - *test_1_15
+        - *test_1_16_without_py37
+        - *test_unspecified
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
@@ -133,7 +153,9 @@ matrix:
         - pyenv global 2.7.14 3.6.3
       script:
         - *test_1_14
-        - *test_1_15_and_unspecified
+        - *test_1_15
+        - *test_1_16_without_py37
+        - *test_unspecified
 
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,23 +105,10 @@ matrix:
       env:
         - *env_osx_openssl
         - CACHE_NAME="osx.sierra"
-      # OSX 10.12 Sierra frequently flakes when running with Pantsd. Restore the original
-      # tests once https://github.com/pantsbuild/pants/issues/6714 and
-      # https://github.com/pantsbuild/pants/issues/7323 are resolved.
-      script:
-        - ./build-support/ci.py
-          --pants-versions 1.14.0
-          --python-versions unspecified
-          --skip-pantsd-tests
-        - ./build-support/ci.py
-          --pants-versions unspecified 1.15.0
-          --python-versions unspecified 2.7 3.6
-          --skip-pantsd-tests
-        - ./build-support/ci.py
-          --pants-versions config
-          --python-versions unspecified 2.7 3.6 3.7
-          --skip-pantsd-tests
-
+        # OSX 10.12 Sierra frequently flakes when running with Pantsd. Restore the
+        # original tests once https://github.com/pantsbuild/pants/issues/6714 and
+        # https://github.com/pantsbuild/pants/issues/7323 are resolved.
+        - SKIP_PANTSD_TESTS=true
 
     - name: "OSX 10.13 - High Sierra"
       <<: *osx_setup

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -45,11 +45,12 @@ class PythonVersion(Enum):
 def main() -> None:
   args = create_parser().parse_args()
   envs = itertools.product(args.pants_versions, args.python_versions)
+  skip_pantsd_tests = args.skip_pantsd_tests or "SKIP_PANTSD_TESTS" in os.environ
   for pants_version, python_version in envs:
     run_tests_with_env(
       pants_version=pants_version,
       python_version=python_version,
-      skip_pantsd_tests=args.skip_pantsd_tests
+      skip_pantsd_tests=skip_pantsd_tests
     )
 
 

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.15.0
+pants_version: 1.16.dev2
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.16.dev2
+pants_version: 1.16.0.dev2
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',


### PR DESCRIPTION
We restored support in https://github.com/pantsbuild/pants/pull/7578. Now that 1.16.0.dev2 is out, we should confirm this works before the stable release is cut.

We must avoid running these new tests on Ubuntu Precise and Trusty because they do not have Python 3.7 installed.

We also refactor how we handle `.travis.yml` script entries + allow skipping Pantsd tests via the env var `SKIP_PANTSD_TESTS` to result in less duplication.