### PR TITLE
Run `shellcheck.py` over build-support scripts

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -1,5 +1,3 @@
-CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
-
 TRAVIS_FOLD_STATE="/tmp/.travis_fold_current"
 
 CLEAR_LINE="\x1b[K"
@@ -23,12 +21,12 @@ function green() {
 }
 
 # Initialization for elapsed()
-: ${elapsed_start_time:=$(date +'%s')}
+: "${elapsed_start_time:=$(date +'%s')}"
 export elapsed_start_time
 
 function elapsed() {
   now=$(date '+%s')
-  elapsed_secs=$(( $now - $elapsed_start_time ))
+  elapsed_secs=$((now - elapsed_start_time))
   echo $elapsed_secs | awk '{printf "%02d:%02d\n",int($1/60), int($1%60)}'
 }
 

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -4,6 +4,7 @@
 
 import shutil
 import subprocess
+from glob import glob
 
 from common import die, green
 
@@ -20,7 +21,8 @@ def ensure_shellcheck_installed() -> None:
 
 
 def run_shellcheck() -> None:
-  command = ["shellcheck", "--shell=bash", "./pants"]
+  build_support_scripts = glob("build-support/**/*.sh", recursive=True)
+  command = ["shellcheck", "--shell=bash", "./pants"] + build_support_scripts
   try:
     subprocess.run(command, check=True)
   except subprocess.CalledProcessError:

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -21,8 +21,8 @@ def ensure_shellcheck_installed() -> None:
 
 
 def run_shellcheck() -> None:
-  build_support_scripts = glob("build-support/**/*.sh", recursive=True)
-  command = ["shellcheck", "--shell=bash", "./pants"] + build_support_scripts
+  targets = glob("**/*.sh", recursive=True)
+  command = ["shellcheck", "--shell=bash"] + targets
   try:
     subprocess.run(command, check=True)
   except subprocess.CalledProcessError:

--- a/build-support/shellcheck.py
+++ b/build-support/shellcheck.py
@@ -21,7 +21,7 @@ def ensure_shellcheck_installed() -> None:
 
 
 def run_shellcheck() -> None:
-  targets = glob("**/*.sh", recursive=True)
+  targets = glob("./**/*.sh", recursive=True) + ["./pants"]
   command = ["shellcheck", "--shell=bash"] + targets
   try:
     subprocess.run(command, check=True)


### PR DESCRIPTION
Test code should be high quality too. We can cheaply improve our build-support code quality by extending `shellcheck.py` to run against it, in addition to checking `./pants`.