### PR TITLE
Mark scripts and tests as Pants targets to unlock benefits like using Pytest and isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ test_1_16_without_py37: &test_1_16_without_py37 >
   --python-versions unspecified 2.7 3.6
 
 test_first_time_install: &test_first_time_install >
-  ./build-support/test_first_time_install.py
+  ./pants test tests:first_time_install
 
 script:
   - *test_1_14

--- a/build-support/BUILD
+++ b/build-support/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'common',
+  sources = 'common.py',
+)
+
+python_binary(
+  name='ci',
+  sources='ci.py',
+  dependencies=[
+    ':common',
+  ],
+)
+
+python_binary(
+  name='shellcheck',
+  sources='shellcheck.py',
+  dependencies=[
+    ':common',
+  ],
+)

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -4,9 +4,6 @@
 """Utils for scripts to interface with the outside world."""
 
 import configparser
-import os
-import shutil
-import tempfile
 import time
 from contextlib import contextmanager
 from enum import Enum
@@ -71,36 +68,6 @@ def travis_section(slug: str, message: str):
   finally:
     travis_fold("end", read_travis_fold_state())
     remove_travis_fold_state()
-
-# --------------------------------------------------------
-# Setup hermetic environment
-# --------------------------------------------------------
-
-@contextmanager
-def copy_pants_into_tmpdir():
-  with tempfile.TemporaryDirectory() as tmpdir:
-    # NB: Unlike the install guide's instruction to curl the `./pants` script, we directly
-    # copy it to ensure we are using the branch's version of the script and to avoid
-    # network pings.
-    shutil.copy("pants", f"{tmpdir}/pants")
-    yield tmpdir
-
-
-@contextmanager
-def set_pants_cache_to_tmpdir():
-  with tempfile.TemporaryDirectory() as tmpdir:
-    original_env = os.environ.copy()
-    os.environ["PANTS_HOME"] = tmpdir
-    try:
-      yield
-    finally:
-      os.environ = original_env
-
-
-@contextmanager
-def setup_pants_in_tmpdir():
-  with set_pants_cache_to_tmpdir(), copy_pants_into_tmpdir() as buildroot_tmpdir:
-    yield buildroot_tmpdir
 
 # --------------------------------------------------------
 # Rewrite pants.ini

--- a/pants.ini
+++ b/pants.ini
@@ -4,3 +4,6 @@ pants_version: 1.16.0.dev2
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',
   ]
+
+[python-setup]
+interpreter_constraints: ['CPython>=3.6']

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version: 1.16.0.dev2
+pants_version: 1.16.0.dev3
 
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',

--- a/pants.ini
+++ b/pants.ini
@@ -6,4 +6,4 @@ plugins: [
   ]
 
 [python-setup]
-interpreter_constraints: ['CPython>=3.6']
+interpreter_constraints: ['CPython>=3.6,<4']

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'test_base',
+  sources = 'test_base.py',
+)
+
+python_tests(
+  name='first_time_install',
+  sources='test_first_time_install.py',
+  dependencies=[
+    ':test_base',
+  ],
+)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from typing import Iterator
+from unittest import TestCase
+
+
+class TestBase(TestCase):
+  """A base class with useful utils for tests."""
+
+  @contextmanager
+  def copy_pants_into_tmpdir(self) -> Iterator[str]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+      # NB: Unlike the install guide's instruction to curl the `./pants` script, we directly
+      # copy it to ensure we are using the branch's version of the script and to avoid
+      # network pings.
+      shutil.copy("pants", f"{tmpdir}/pants")
+      yield tmpdir
+
+  @contextmanager
+  def set_pants_cache_to_tmpdir(self) -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+      original_env = os.environ.copy()
+      os.environ["PANTS_HOME"] = tmpdir
+      try:
+        yield
+      finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+  @contextmanager
+  def setup_pants_in_tmpdir(self) -> Iterator[str]:
+    with self.set_pants_cache_to_tmpdir(), self.copy_pants_into_tmpdir() as buildroot_tmpdir:
+      yield buildroot_tmpdir

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -29,8 +29,7 @@ class TestBase(TestCase):
       try:
         yield
       finally:
-        os.environ.clear()
-        os.environ.update(original_env)
+        os.environ = original_env
 
   @contextmanager
   def setup_pants_in_tmpdir(self) -> Iterator[str]:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator
 from unittest import TestCase
 
 
@@ -13,7 +12,7 @@ class TestBase(TestCase):
   """A base class with useful utils for tests."""
 
   @contextmanager
-  def copy_pants_into_tmpdir(self) -> Iterator[str]:
+  def copy_pants_into_tmpdir(self):
     with tempfile.TemporaryDirectory() as tmpdir:
       # NB: Unlike the install guide's instruction to curl the `./pants` script, we directly
       # copy it to ensure we are using the branch's version of the script and to avoid
@@ -22,7 +21,7 @@ class TestBase(TestCase):
       yield tmpdir
 
   @contextmanager
-  def set_pants_cache_to_tmpdir(self) -> Iterator[None]:
+  def set_pants_cache_to_tmpdir(self):
     with tempfile.TemporaryDirectory() as tmpdir:
       original_env = os.environ.copy()
       os.environ["PANTS_HOME"] = tmpdir
@@ -32,6 +31,6 @@ class TestBase(TestCase):
         os.environ = original_env
 
   @contextmanager
-  def setup_pants_in_tmpdir(self) -> Iterator[str]:
+  def setup_pants_in_tmpdir(self):
     with self.set_pants_cache_to_tmpdir(), self.copy_pants_into_tmpdir() as buildroot_tmpdir:
       yield buildroot_tmpdir

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
@@ -11,15 +10,14 @@ https://github.com/pantsbuild/pants/blob/master/tests/python/pants_test/core_tas
 
 import re
 import subprocess
-import unittest
 
-from common import setup_pants_in_tmpdir, travis_section
+from test_base import TestBase
 
 
-class TestFirstTimeInstall(unittest.TestCase):
+class TestFirstTimeInstall(TestBase):
 
   def test_venv_name_uses_most_recent_stable_release(self) -> None:
-    with setup_pants_in_tmpdir() as tmpdir:
+    with self.setup_pants_in_tmpdir() as tmpdir:
       completed_process = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -37,7 +35,7 @@ class TestFirstTimeInstall(unittest.TestCase):
       ))
 
   def test_only_bootstraps_the_first_time(self) -> None:
-    with setup_pants_in_tmpdir() as tmpdir:
+    with self.setup_pants_in_tmpdir() as tmpdir:
       first_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -58,7 +56,3 @@ class TestFirstTimeInstall(unittest.TestCase):
       ).stderr
       # Check that stderr is falsy, i.e. there is no output.
       self.assertFalse(second_run_pants_script_logging)
-
-if __name__ == "__main__":
-  with travis_section("PantsFirstTimeInstall", "Testing first time install."):
-    unittest.main()

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -39,7 +39,6 @@ class TestFirstTimeInstall(TestBase):
       first_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
-        stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         encoding="utf-8",
         cwd=tmpdir
@@ -49,7 +48,6 @@ class TestFirstTimeInstall(TestBase):
       second_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
-        stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         encoding="utf-8",
         cwd=tmpdir


### PR DESCRIPTION
Because our tests and build-support scripts are written in Python, they are valid candidates for Pants targets.

Marking them as targets allows for the `build-support` and `tests` code to improve in multiple ways:

* Can use Pytest via `./pants test ::`, which brings benefits like capturing stdout and stderr
* Can run `./pants fmt.isort ::` for import checks
* Can run `./pants lint ::` to catch bugs in tests and scripts
* Can run `./pants mypy ::` to catch bugs in tests and scripts
* Allows creating / importing new `TestBase`, so that test support code can be kept separate from script support code (i.e. `common.py`)