### PR TITLE
Stop using Pyenv shims for custom installed Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
-    - PATH="${PYENV_ROOT}/shims:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
 test_1_14: &test_1_14 >
   ./build-support/ci.py

--- a/build-support/install_python_for_ci.sh
+++ b/build-support/install_python_for_ci.sh
@@ -28,5 +28,3 @@ for python_version in "${PYTHON_VERSIONS[@]}"; do
     "${PYENV_BIN}" install "${python_version}"
   fi
 done
-
-"${PYENV_BIN}" global "${PYTHON_VERSIONS[@]}"


### PR DESCRIPTION
Shims are designed for humans, not machines. Most tangibly, they resulted in this unexpected behavior https://github.com/pantsbuild/pants/issues/7636 on the OSX 10.12 shard.

We still use `pyenv global` on the Precise and Xenial shards, however, because Travis pre-installs Python via Pyenv on those shards and this is the standard way to fix an issue with their implementation so that the interpreters become discoverable on the `PATH`. We stick with Travis's pre-installed versions for performance and a smaller cache, at the cost of a less uniform and more complex Python setup across CI.