### PR TITLE
Add `precommit.py` script to easily lint all the repo's code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.pants.workdir.file_lock
 /.pids/
 
+/.cache/
 /.mypy_cache/
 
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ linux_setup: &linux_setup
 
 matrix:
   include:
-    - name: "Lint ./pants script"
+    - name: "Lint scripts, tests, and build-support"
       <<: *linux_setup
       dist: xenial
       before_install:
@@ -89,8 +89,7 @@ matrix:
           packages:
             - shellcheck
       script:
-        - ./build-support/shellcheck.py
-        - ./build-support/mypy.py
+        - ./build-support/precommit.py
 
     - name: "OSX 10.11 - El Capitan"
       <<: *osx_setup

--- a/build-support/BUILD
+++ b/build-support/BUILD
@@ -23,6 +23,16 @@ python_binary(
 )
 
 python_binary(
+  name='precommit',
+  sources='precommit.py',
+  dependencies=[
+    ':common',
+    ':mypy',
+    ':shellcheck',
+  ],
+)
+
+python_binary(
   name='shellcheck',
   sources='shellcheck.py',
   dependencies=[

--- a/build-support/precommit.py
+++ b/build-support/precommit.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import subprocess
+
+import mypy
+import shellcheck
+
+
+def main() -> None:
+  print("* Checking shell scripts via shellcheck")
+  shellcheck.main()
+
+  print("\n* Checking import order")
+  subprocess.run(["./pants", "fmt.isort", "::", "--", "--check-only"], check=True)
+
+  print("\n* Checking lint")
+  subprocess.run(["./pants", "lint", "::"], check=True)
+
+  print("\n* Checking types")
+  mypy.main()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Provides one entry point to check the import order, Python lint, MyPy types, and to run shellcheck.

This is not yet converted into a formal git hook to avoid adding too much complexity.