### PR TITLE
Add MyPy config and script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 /.pants.workdir.file_lock
 /.pids/
 
+/.mypy_cache/
+
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ matrix:
             - shellcheck
       script:
         - ./build-support/shellcheck.py
+        - ./build-support/mypy.py
 
     - name: "OSX 10.11 - El Capitan"
       <<: *osx_setup

--- a/build-support/BUILD
+++ b/build-support/BUILD
@@ -15,6 +15,14 @@ python_binary(
 )
 
 python_binary(
+  name='mypy',
+  sources='mypy.py',
+  dependencies=[
+    ':common',
+  ],
+)
+
+python_binary(
   name='shellcheck',
   sources='shellcheck.py',
   dependencies=[

--- a/build-support/ci.py
+++ b/build-support/ci.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from contextlib import contextmanager
 from enum import Enum
-from typing import List
+from typing import Iterator, List
 
 from common import (CONFIG_GLOBAL_SECTION, banner, die, read_config,
                     temporarily_rewrite_config, travis_section)
@@ -27,8 +27,8 @@ class PantsVersion(Enum):
   one_sixteen = "1.16.0"
   one_seventeen = "1.17.0"
 
-  def __str__(self):
-      return self.value
+  def __str__(self) -> str:
+      return str(self.value)
 
 
 class PythonVersion(Enum):
@@ -37,8 +37,8 @@ class PythonVersion(Enum):
   py36 = "3.6"
   py37 = "3.7"
 
-  def __str__(self):
-    return self.value
+  def __str__(self) -> str:
+    return str(self.value)
 
 
 def main() -> None:
@@ -108,7 +108,7 @@ def run_tests(*, skip_pantsd_tests: bool) -> None:
 
 
 @contextmanager
-def setup_pants_version(test_pants_version: PantsVersion):
+def setup_pants_version(test_pants_version: PantsVersion) -> Iterator[None]:
   """Modify pants.ini to allow the pants version to be a specified version or to keep what was originally there."""
   updated_config = read_config()
   config_entry = "pants_version"
@@ -126,7 +126,7 @@ def setup_pants_version(test_pants_version: PantsVersion):
 
 
 @contextmanager
-def setup_python_version(test_python_version: PythonVersion):
+def setup_python_version(test_python_version: PythonVersion) -> Iterator[None]:
   """Modify pants.ini to allow the Python version to be unspecified or change to what was requested."""
   updated_config = read_config()
   config_entry = "pants_runtime_python_version"

--- a/build-support/common.py
+++ b/build-support/common.py
@@ -8,7 +8,7 @@ import time
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import Tuple
+from typing import Iterator, Tuple
 
 # --------------------------------------------------------
 # Logging utils
@@ -43,7 +43,7 @@ def elapsed_time() -> Tuple[int, int]:
 
 
 @contextmanager
-def travis_section(slug: str, message: str):
+def travis_section(slug: str, message: str) -> Iterator[None]:
   travis_fold_state = "/tmp/.travis_fold_current"
 
   def travis_fold(action: str, target: str) -> None:
@@ -89,7 +89,7 @@ def write_config(config: configparser.ConfigParser) -> None:
 
 
 @contextmanager
-def temporarily_rewrite_config(updated_config: configparser.ConfigParser):
+def temporarily_rewrite_config(updated_config: configparser.ConfigParser) -> Iterator[None]:
   with open(PANTS_INI, "r") as f:
     original_config = f.read()
   write_config(updated_config)

--- a/build-support/mypy.ini
+++ b/build-support/mypy.ini
@@ -1,0 +1,35 @@
+[mypy]
+# optionals
+no_implicit_optional = True
+
+# untyped
+check_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = False
+disallow_incomplete_defs = True
+
+# dynamic typing
+disallow_any_unimported = False
+disallow_any_expr = False
+disallow_any_decorated = False
+disallow_any_explicit = False
+disallow_any_generics = False
+disallow_subclassing_any = False
+
+# strictness
+strict_equality = True
+
+# warnings
+warn_return_any = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+
+# error output
+show_column_numbers = True
+show_traceback = True
+
+# imports
+ignore_missing_imports = False
+follow_imports = normal
+follow_imports_for_stubs = False

--- a/build-support/mypy.ini
+++ b/build-support/mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
+# Refer to https://mypy.readthedocs.io/en/stable/command_line.html
+# for the list of all possible options.
+
 # optionals
 no_implicit_optional = True
 

--- a/build-support/mypy.py
+++ b/build-support/mypy.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import argparse
+import subprocess
+from typing import List
+
+from common import die
+
+
+def main() -> None:
+  targets = create_parser().parse_args().targets
+  run_mypy(targets)
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(description="Run MyPy with our config file.")
+  parser.add_argument(
+    "targets",
+    default=["::"],
+    nargs="*",
+    help="Pants targets, e.g. `tests::`.",
+  )
+  return parser
+
+def run_mypy(targets: List[str]) -> None:
+  command = [
+    "./pants",
+    "mypy",
+    "--mypy-mypy-version=0.701",
+    "--config-file=build-support/mypy.ini",
+  ]
+  try:
+    subprocess.run(command + targets, check=True)
+  except subprocess.CalledProcessError:
+    die("Please fix the above type errors and run again.")
+
+
+if __name__ == "__main__":
+  main()

--- a/pants.ini
+++ b/pants.ini
@@ -2,7 +2,7 @@
 pants_version: 1.16.0.dev3
 
 plugins: [
-    'pantsbuild.pants.contrib.go==%(pants_version)s',
+    'pantsbuild.pants.contrib.mypy==%(pants_version)s',
   ]
 
 [python-setup]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from typing import Iterator
 from unittest import TestCase
 
 
@@ -12,7 +13,7 @@ class TestBase(TestCase):
   """A base class with useful utils for tests."""
 
   @contextmanager
-  def copy_pants_into_tmpdir(self):
+  def copy_pants_into_tmpdir(self) -> Iterator[str]:
     with tempfile.TemporaryDirectory() as tmpdir:
       # NB: Unlike the install guide's instruction to curl the `./pants` script, we directly
       # copy it to ensure we are using the branch's version of the script and to avoid
@@ -21,16 +22,17 @@ class TestBase(TestCase):
       yield tmpdir
 
   @contextmanager
-  def set_pants_cache_to_tmpdir(self):
+  def set_pants_cache_to_tmpdir(self) -> Iterator[None]:
     with tempfile.TemporaryDirectory() as tmpdir:
       original_env = os.environ.copy()
       os.environ["PANTS_HOME"] = tmpdir
       try:
         yield
       finally:
-        os.environ = original_env
+        os.environ.clear()
+        os.environ.update(original_env)
 
   @contextmanager
-  def setup_pants_in_tmpdir(self):
+  def setup_pants_in_tmpdir(self) -> Iterator[str]:
     with self.set_pants_cache_to_tmpdir(), self.copy_pants_into_tmpdir() as buildroot_tmpdir:
       yield buildroot_tmpdir


### PR DESCRIPTION
Since most of the code in this repo now uses Python 3 with type hints, it would be good to actually enforce that those hints are correct in CI.

This PR also allows us to experiment with MyPy to upstream to Pants, e.g. copying the new Python script over.