### PR TITLE
Add fixed locale settings

### DIFF
--- a/pants
+++ b/pants
@@ -190,4 +190,4 @@ pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 export no_proxy='*'
 
-exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"
+exec env LC_ALL=en_US.UTF-8 env LANG=en_US.UTF-8 "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"


### PR DESCRIPTION
 LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8

are needed for pants to work.

pants create this error:

```shell
pants.bin.pants_loader.InvalidLocaleError: 
Your system's preferred encoding is `US-ASCII`, but Pants requires `UTF-8`.
Specifically, Python's `locale.getpreferredencoding()` must resolve to `UTF-8`.

Fix it by setting the LC_* and LANG environment settings. Example:
  LC_ALL=en_US.UTF-8
  LANG=en_US.UTF-8
Or, bypass it by setting the below environment variable. 
  PANTS_IGNORE_UNRECOGNIZED_ENCODING=1
Note: we cannot guarantee consistent behavior with this bypass enabled.
```

so it is better to set it to a fixed value in the setup script.
Pants create its own virtual env so the it doesn't read the system settings on MacOS.