### PR TITLE
Fix broken Python 2 installs due to enum34 regression

### DIFF
--- a/pants
+++ b/pants
@@ -168,6 +168,9 @@ function bootstrap_pants {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install"
       "${staging_dir}/install/bin/pip" install -U pip
+      # TODO: remove this once enum34 stabilizes. See
+      # https://bitbucket.org/stoneleaf/enum34/issues/27/enum34-118-broken.
+      "${staging_dir}/install/bin/pip" install enum34==1.1.6
       "${staging_dir}/install/bin/pip" install "${pants_requirement}"
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
       mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"


### PR DESCRIPTION
enum34 recently broke for Python 2.7. This is used transitively by `py_zipkin` and results in our Python 2.7 builds failing in CI, which means that they also fail for users with Pants <=1.16 who are trying to run Pants with Python 2.7.

See https://bitbucket.org/stoneleaf/enum34/issues/27/enum34-118-broken.