### PR TITLE
Fix disabled Pyenv versions breaking the script

### DIFF
--- a/pants
+++ b/pants
@@ -116,7 +116,15 @@ function determine_default_python_exe {
     supported_message='3.6+'
   fi
   for version in "${supported_python_versions[@]}"; do
-    command -v "python${version}" && return 0
+    interpreter_path="$(command -v "python${version}")"
+    if [[ -z "${interpreter_path}" ]]; then
+      continue
+    fi
+    # Check if the Python version in installed via Pyenv but not activated.
+    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
+      continue
+    fi
+    echo "${interpreter_path}" && return 0
   done
   die "No valid Python interpreter found. For this Pants version, Pants requires Python ${supported_message}."
 }

--- a/pants
+++ b/pants
@@ -120,7 +120,7 @@ function determine_default_python_exe {
     if [[ -z "${interpreter_path}" ]]; then
       continue
     fi
-    # Check if the Python version in installed via Pyenv but not activated.
+    # Check if the Python version is installed via Pyenv but not activated.
     if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
       continue
     fi


### PR DESCRIPTION
Closes https://github.com/pantsbuild/setup/issues/62.

A frequent idiom with Python development is to use Pyenv to globally install several Python versions, but to only activate certain versions locally. This would break the `./pants` script, as it would think that an un-activated version like `python3.8` was valid when really it would fail when being run.