### PR TITLE
Use pyenv to test Python interpreter resolution rather than `--pants-runtime-python-version`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ branches:
 
 env:
   global:
+    - PYENV_PY27_VERSION=2.7.17
     - PYENV_PY36_VERSION=3.6.10
     - PYENV_PY37_VERSION=3.7.6
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
@@ -39,7 +41,7 @@ osx_setup: &osx_setup
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+    - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -105,10 +107,11 @@ jobs:
       dist: precise
       sudo: required
       env:
+        - PYENV_ROOT="${HOME}/.pants_pyenv}"
         - CACHE_NAME="linux.precise"
         - SKIP_PYTHON37_TESTS=true
       before_install:
-        - ./build-support/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+        - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
 
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,7 @@ jobs:
         - CACHE_NAME="linux.trusty"
         - SKIP_PYTHON37_TESTS=true
       before_install:
+        - pyenv versions
         - pyenv global 2.7.14 3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
@@ -128,6 +129,7 @@ jobs:
       env:
         - CACHE_NAME="linux.xenial"
       before_install:
+        - pyenv versions
         - pyenv global 2.7.15 3.6.7 3.7.1
 
     - name: "Ubuntu 18.04 - Bionic"
@@ -136,4 +138,5 @@ jobs:
       env:
         - CACHE_NAME="linux.bionic"
       before_install:
+        - pyenv versions
         - pyenv global 2.7.17 3.6.9 3.7.5 3.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,6 @@ jobs:
         - CACHE_NAME="linux.trusty"
         - SKIP_PYTHON37_TESTS=true
       before_install:
-        - pyenv versions
         - pyenv global 2.7.14 3.6.3
 
     - name: "Ubuntu 16.04 - Xenial"
@@ -129,7 +128,6 @@ jobs:
       env:
         - CACHE_NAME="linux.xenial"
       before_install:
-        - pyenv versions
         - pyenv global 2.7.15 3.6.7 3.7.1
 
     - name: "Ubuntu 18.04 - Bionic"
@@ -138,5 +136,4 @@ jobs:
       env:
         - CACHE_NAME="linux.bionic"
       before_install:
-        - pyenv versions
         - pyenv global 2.7.17 3.6.9 3.7.5 3.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,17 +102,6 @@ jobs:
         - *env_osx_openssl
         - CACHE_NAME="osx.mojave"
 
-    - name: "Ubuntu 12.04 - Precise"
-      <<: *linux_setup
-      dist: precise
-      sudo: required
-      env:
-        - PYENV_ROOT="${HOME}/.pants_pyenv}"
-        - CACHE_NAME="linux.precise"
-        - SKIP_PYTHON37_TESTS=true
-      before_install:
-        - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
-
     - name: "Ubuntu 14.04 - Trusty"
       <<: *linux_setup
       dist: trusty

--- a/build-support/mypy.ini
+++ b/build-support/mypy.ini
@@ -30,7 +30,12 @@ warn_redundant_casts = True
 
 # error output
 show_column_numbers = True
+show_error_context = True
+show_error_codes = True
 show_traceback = True
+pretty = True
+color_output = True
+error_summary = True
 
 # imports
 ignore_missing_imports = False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,12 +33,11 @@ class TestBase(TestCase):
                 "`export PYENV_ROOT=$(pyenv root)`."
             )
         self.pyenv_versions = subprocess.run(
-            [self.pyenv_bin, "versions", "--bare"],
+            [self.pyenv_bin, "versions", "--bare", "--skip-aliases"],
             stdout=subprocess.PIPE,
             encoding="utf-8",
             check=True,
         ).stdout.splitlines()
-        print(self.pyenv_versions)
 
     @contextmanager
     def copy_pants_into_tmpdir(self) -> Iterator[str]:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -38,6 +38,7 @@ class TestBase(TestCase):
             encoding="utf-8",
             check=True,
         ).stdout.splitlines()
+        print(self.pyenv_versions)
 
     @contextmanager
     def copy_pants_into_tmpdir(self) -> Iterator[str]:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,14 +4,40 @@
 import configparser
 import os
 import shutil
+import subprocess
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator, Optional
 from unittest import TestCase
 
 
 class TestBase(TestCase):
     """A base class with useful utils for tests."""
+
+    def setUp(self) -> None:
+        self.pyenv_bin: str
+        if "PYENV_BIN" in os.environ:
+            self.pyenv_bin = os.environ["PYENV_BIN"]
+        else:
+            pyenv_path = shutil.which("pyenv")
+            if pyenv_path is None:
+                raise ValueError(
+                    "Pyenv must be installed. The binary `pyenv` must either be discoverable from "
+                    "the `$PATH` or you must set the environment variable `PYENV_BIN`."
+                )
+            self.pyenv_bin = pyenv_path
+        if "PYENV_ROOT" not in os.environ:
+            raise ValueError(
+                "The environment variable `PYENV_ROOT` must be set. Please run "
+                "`export PYENV_ROOT=$(pyenv root)`."
+            )
+        self.pyenv_versions = subprocess.run(
+            [self.pyenv_bin, "versions", "--bare"],
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+            check=True,
+        ).stdout.splitlines()
 
     @contextmanager
     def copy_pants_into_tmpdir(self) -> Iterator[str]:
@@ -38,22 +64,53 @@ class TestBase(TestCase):
         with self.set_pants_cache_to_tmpdir(), self.copy_pants_into_tmpdir() as buildroot_tmpdir:
             yield buildroot_tmpdir
 
-    def create_pants_ini(
-        self, *, parent_folder: str, pants_version: str, python_version: Optional[str] = None
-    ) -> None:
+    @contextmanager
+    def maybe_run_pyenv_local(
+        self, python_version: Optional[str], *, parent_folder: str
+    ) -> Iterator[None]:
+        if python_version is None:
+            yield
+            return
+
+        def is_compatible(pyenv_version: str) -> bool:
+            major, minor, _ = pyenv_version.split(".")
+            return f"{major}.{minor}" == python_version
+
+        compatible_pyenv_version = next(
+            (
+                pyenv_version
+                for pyenv_version in self.pyenv_versions
+                if is_compatible(pyenv_version)
+            ),
+            None,
+        )
+        if compatible_pyenv_version is None:
+            raise ValueError(
+                f"Python {python_version} is not installed via Pyenv. Please install with "
+                f"`pyenv install`. All installed versions: {', '.join(self.pyenv_versions)}."
+            )
+        subprocess.run(
+            [self.pyenv_bin, "local", compatible_pyenv_version], cwd=parent_folder, check=True
+        )
+        try:
+            yield
+        finally:
+            subprocess.run(
+                [self.pyenv_bin, "local", "--unset", compatible_pyenv_version],
+                cwd=parent_folder,
+                check=True,
+            )
+
+    @staticmethod
+    def create_pants_ini(*, parent_folder: str, pants_version: str) -> None:
         config = configparser.ConfigParser()
         config["GLOBAL"] = {
             "pants_version": pants_version,
             "plugins": "['pantsbuild.pants.contrib.go==%(pants_version)s']",
         }
-        # TODO: stop using `pants_runtime_python_versoin`, which is no longer allowed in Pants. Figure
-        # out how to set the Python version some other way, which could be via the $PYTHON
-        # env var (although that won't test that we resolve the default correctly..).
-        if python_version is not None:
-            config["GLOBAL"]["pants_runtime_python_version"] = python_version
         with open(f"{parent_folder}/pants.ini", "w") as f:
             config.write(f)
 
-    def create_dummy_build(self, *, parent_folder: str) -> None:
-        with open(f"{parent_folder}/BUILD", "w") as f:
-            f.write("target(name='test')\n")
+    @staticmethod
+    def create_dummy_build(*, parent_folder: str) -> None:
+        Path(parent_folder, "BUILD").write_text("target(name='test')\n")

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -15,10 +15,10 @@ class TestSanityCheck(TestBase):
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
 
-        with self.setup_pants_in_tmpdir() as tmpdir:
-            self.create_pants_ini(
-                parent_folder=tmpdir, pants_version=pants_version, python_version=python_version
-            )
+        with self.setup_pants_in_tmpdir() as tmpdir, self.maybe_run_pyenv_local(
+            python_version, parent_folder=tmpdir
+        ):
+            self.create_pants_ini(parent_folder=tmpdir, pants_version=pants_version)
             self.create_dummy_build(parent_folder=tmpdir)
 
             def run_command(command: List[str], **kwargs: Any) -> None:
@@ -45,5 +45,5 @@ class TestSanityCheck(TestBase):
         self.check_for_all_python_versions("2.7", "3.6", pants_version="1.15.0")
 
     def test_pants_1_16(self) -> None:
-        self.sanity_check(python_version=None, pants_version="1.16.0.dev3")
-        self.check_for_all_python_versions("2.7", "3.6", "3.7", pants_version="1.16.0.dev3")
+        self.sanity_check(python_version=None, pants_version="1.16.0")
+        self.check_for_all_python_versions("2.7", "3.6", "3.7", pants_version="1.16.0")

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,7 @@ skipsdist = true
 envlist = format-check, lint, typecheck, test
 
 [testenv]
-# NB: This is to ensure that Ubuntu 12.04 does not try to use Python 3.5. We use Py36, rather than
-# Py37, because Py36 is the only version we are guaranteed to have on every CI environment.
-basepython = python3.6
+basepython = python3
 
 [testenv:test]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ passenv =
     # These are to support directing test environments to the correct OpenSSL on OSX.
     LDFLAGS
     CPPFLAGS
+    # We use Pyenv to configure which Python versions are used.
+    PYENV_BIN
+    PYENV_ROOT
 
 [testenv:format-run]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ skipsdist = true
 envlist = format-check, lint, typecheck, test
 
 [testenv]
-basepython = python3
+# NB: This is to ensure that Ubuntu 12.04 does not try to use Python 3.5. We use Py36, rather than
+# Py37, because Py36 is the only version we are guaranteed to have on every CI environment.
+basepython = python3.6
 
 [testenv:test]
 deps =


### PR DESCRIPTION
We previously used `--pants-runtime-python-version` to force Pants to use certain Python versions. This was not safe to keep doing, though, because we ended up removing this option.

Instead, we can use Pyenv to get the same effect.

This will allow us to start testing default Python interpreter resolution for Pants > 1.16.

We remove Ubuntu 12.04 from CI to land this, as it has been EOL since April 2017 and causes issues with getting Pyenv to work properly.