### PR TITLE
Remove support for Pants <= 1.16.0

### DIFF
--- a/pants
+++ b/pants
@@ -111,7 +111,6 @@ function determine_default_python_exe {
     fi
     echo "${interpreter_path}" && return 0
   done
-  die "No valid Python interpreter found. Pants requires Python 3.6+ to run."
 }
 
 function determine_python_exe {
@@ -119,8 +118,18 @@ function determine_python_exe {
     python_bin_name="${PYTHON_BIN_NAME}"
   else
     python_bin_name="$(determine_default_python_exe)"
+    if [[ -z "${python_bin_name}" ]]; then
+      die "No valid Python interpreter found. Pants requires Python 3.6+ to run."
+    fi
   fi
-  get_exe_path_or_die "${python_bin_name}"
+  python_exe="$(get_exe_path_or_die "${python_bin_name}")"
+  major_minor_version="$(get_python_major_minor_version "${python_exe}")"
+  for valid_version in '36' '37' '38' '39'; do
+    if [[ "${major_minor_version}" == "${valid_version}" ]]; then
+      echo "${python_exe}" && return 0
+    fi
+  done
+  die "Invalid Python interpreter version for ${python_exe}. Pants requires Python 3.6+ to run."
 }
 
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX

--- a/pants
+++ b/pants
@@ -73,13 +73,11 @@ EOF
 
 # The high-level flow:
 # 1.) Resolve the Pants version from pants.ini or from the latest stable
-#     release to PyPi, so that we know what to name the venv folder and which
-#     Python versions we can use.
+#     release to PyPI, so that we know what to name the venv (virtual environment) folder and what
+#     to install with Pip.
 # 2.) Resolve the Python interpreter, first reading from the env var $PYTHON,
-#     then reading from pants.ini, then determining the default based off of
-#     which Python versions the Pants version supports.
-# 3.) Check if the venv (virtual environment) already exists via a naming/path convention,
-#     and create the venv if not found.
+#     then defaulting to Python 3.6+.
+# 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
 # 4.) Execute Pants with the resolved Python interpreter and venv.
 #
 # After that, Pants itself will handle making sure any requested plugins
@@ -87,35 +85,22 @@ EOF
 
 function determine_pants_version {
   pants_version="$(get_pants_ini_config_value 'pants_version')"
-  if [[ -n "${pants_version}" ]]; then
-    echo "${pants_version}"
-  else
-    curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
-      python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])"
+  if [[ -z "${pants_version}" ]]; then
+    pants_version="$(curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
+      python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])")"
   fi
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 16 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.16.0. Instead,
+either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
+https://raw.githubusercontent.com/pantsbuild/setup/3bb006e4a792ae83d7059ea76c0372ece7c1069d/pants."
+  fi
+  echo "${pants_version}"
 }
 
 function determine_default_python_exe {
-  pants_version="$1"
-  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
-  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
-    supported_python_versions=('2.7')
-    supported_message='2.7'
-  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
-    supported_python_versions=('3.6' '2.7')
-    supported_message='2.7 or 3.6'
-  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 16 ]]; then
-    supported_python_versions=('3.6' '3.7' '2.7')
-    supported_message='2.7, 3.6, or 3.7'
-  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 17 ]]; then
-    supported_python_versions=('3.6' '3.7' '3.8' '3.9')
-    supported_message='3.6+'
-  else
-    supported_python_versions=('3.9' '3.8' '3.7' '3.6')
-    supported_message='3.6+'
-  fi
-  for version in "${supported_python_versions[@]}"; do
+  for version in '3.6' '3.7' '3.8' '3.9'; do
     interpreter_path="$(command -v "python${version}")"
     if [[ -z "${interpreter_path}" ]]; then
       continue
@@ -126,20 +111,14 @@ function determine_default_python_exe {
     fi
     echo "${interpreter_path}" && return 0
   done
-  die "No valid Python interpreter found. For this Pants version, Pants requires Python ${supported_message}."
+  die "No valid Python interpreter found. Pants requires Python 3.6+ to run."
 }
 
 function determine_python_exe {
-  pants_version="$1"
   if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
     python_bin_name="${PYTHON_BIN_NAME}"
   else
-    interpreter_version="$(get_pants_ini_config_value 'pants_runtime_python_version')"
-    if [[ -n "${interpreter_version}" ]]; then
-      python_bin_name="python${interpreter_version}"
-    else
-      python_bin_name="$(determine_default_python_exe "${pants_version}")"
-    fi
+    python_bin_name="$(determine_default_python_exe)"
   fi
   get_exe_path_or_die "${python_bin_name}"
 }
@@ -176,9 +155,6 @@ function bootstrap_pants {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install"
       "${staging_dir}/install/bin/pip" install -U pip
-      # TODO: remove this once enum34 stabilizes. See
-      # https://bitbucket.org/stoneleaf/enum34/issues/27/enum34-118-broken.
-      "${staging_dir}/install/bin/pip" install "enum34==1.1.6 ; python_version == \"2.7\""
       "${staging_dir}/install/bin/pip" install "${pants_requirement}"
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
       mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"
@@ -191,7 +167,7 @@ function bootstrap_pants {
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 pants_version="$(determine_pants_version)"
-python="$(determine_python_exe "${pants_version}")"
+python="$(determine_python_exe)"
 pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -102,12 +102,15 @@ class TestBase(TestCase):
             )
 
     @staticmethod
-    def create_pants_ini(*, parent_folder: str, pants_version: str) -> None:
+    def create_pants_ini(*, parent_folder: str, pants_version: Optional[str]) -> None:
         config = configparser.ConfigParser()
-        config["GLOBAL"] = {
-            "pants_version": pants_version,
-            "plugins": "['pantsbuild.pants.contrib.go==%(pants_version)s']",
-        }
+        if pants_version is not None:
+            config["GLOBAL"] = {
+                "pants_version": pants_version,
+                "plugins": "['pantsbuild.pants.contrib.go==%(pants_version)s']",
+            }
+        else:
+            config["GLOBAL"] = {"plugins": "['pantsbuild.pants.contrib.go']"}
         with open(f"{parent_folder}/pants.ini", "w") as f:
             config.write(f)
 

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -4,6 +4,7 @@
 """Test that the first time installation flow described by
 https://www.pantsbuild.org/install.html#recommended-installation works as expected."""
 
+import os
 import re
 import subprocess
 
@@ -59,11 +60,13 @@ class TestFirstTimeInstall(TestBase):
         assert "does not work with Pants <= 1.16.0" in result.stderr
 
     def test_python2_fails(self) -> None:
-        with self.setup_pants_in_tmpdir() as tmpdir, self.maybe_run_pyenv_local(
-            "2.7", parent_folder=tmpdir
-        ):
+        with self.setup_pants_in_tmpdir() as tmpdir:
             result = subprocess.run(
-                ["./pants", "--version"], cwd=tmpdir, stderr=subprocess.PIPE, encoding="utf-8"
+                ["./pants", "--version"],
+                cwd=tmpdir,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+                env={**os.environ, "PYTHON": "python2"},
             )
         assert result.returncode != 0
         assert "Pants requires Python 3.6+ to run" in result.stderr

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -11,7 +11,7 @@ from test_base import TestBase
 
 
 class TestSanityCheck(TestBase):
-    def sanity_check(self, *, pants_version: str, python_version: Optional[str]) -> None:
+    def sanity_check(self, *, pants_version: Optional[str], python_version: Optional[str]) -> None:
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
 
@@ -31,19 +31,18 @@ class TestSanityCheck(TestBase):
                 run_command(version_command, env=env_with_pantsd)
                 run_command(list_command, env=env_with_pantsd)
 
-    def check_for_all_python_versions(self, *python_versions: str, pants_version: str) -> None:
+    def check_for_all_python_versions(
+        self, *python_versions: str, pants_version: Optional[str]
+    ) -> None:
         for python_version in python_versions:
             if "SKIP_PYTHON37_TESTS" in os.environ and python_version == "3.7":
                 continue
             self.sanity_check(pants_version=pants_version, python_version=python_version)
 
-    def test_pants_1_14(self) -> None:
-        self.sanity_check(python_version=None, pants_version="1.14.0")
+    def test_pants_1_24(self) -> None:
+        self.sanity_check(python_version=None, pants_version="1.24.0")
+        self.check_for_all_python_versions("3.6", "3.7", pants_version="1.24.0")
 
-    def test_pants_1_15(self) -> None:
-        self.sanity_check(python_version=None, pants_version="1.15.0")
-        self.check_for_all_python_versions("2.7", "3.6", pants_version="1.15.0")
-
-    def test_pants_1_16(self) -> None:
-        self.sanity_check(python_version=None, pants_version="1.16.0")
-        self.check_for_all_python_versions("2.7", "3.6", "3.7", pants_version="1.16.0")
+    def test_pants_latest(self) -> None:
+        self.sanity_check(python_version=None, pants_version=None)
+        self.check_for_all_python_versions("3.6", "3.7", pants_version=None)


### PR DESCRIPTION
Pants 1.16.0 is over 9 months old. For new Pants users, it is highly unlikely they will change the default version of Pants 1.24.0 all the way back to 1.16.0. 

By removing this support, we can guarantee that Pants is running with Python 3.6+. This allows us to simplify much of the `./pants` code, e.g. allowing us in a followup to use the stdlib `venv` implementation instead of `virtualenv`.

If users try using this script with Pants 1.16.0 or earlier, we point them to a revision that will work properly.