### PR TITLE
Test Python 3.8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,11 @@ branches:
   only:
     - gh-pages
 
-env:
-  global:
-    - PYENV_PY27_VERSION=2.7.17
-    - PYENV_PY36_VERSION=3.6.10
-    - PYENV_PY37_VERSION=3.7.6
-    - PYENV_PY38_VERSION=3.8.1
-    # NB: Linux shards use Pyenv to pre-install Python. We must not override
-    # PYENV_ROOT on those shards, or their Python will no longer work.
-    - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
-    - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
-    - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-    - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
-    - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
-
 install:
   - pip install tox
 
 script:
   - tox -e test
-
-cache:
-  directories:
-    - ${PYENV_ROOT}
 
 osx_setup: &osx_setup
   os: osx
@@ -36,34 +18,39 @@ osx_setup: &osx_setup
       packages:
         - openssl
   env:
-    - &env_osx_openssl >
+    - &env_osx >
       # These flags are necessary to get OpenSSL working on OSX. See
       # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
+      # We use Pyenv to install all the required Python versions.
+      PYENV_PY27_VERSION=2.7.17
+      PYENV_PY36_VERSION=3.6.10
+      PYENV_PY37_VERSION=3.7.6
+      PYENV_PY38_VERSION=3.8.1
+      PYENV_ROOT="${HOME}/.pants_pyenv}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
   before_install:
     - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}" "${PYENV_PY38_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
     - ulimit -n 8192
-
-linux_setup: &linux_setup
-  os: linux
-  sudo: false
-  language: python
-  python:
-    - "2.7"
-    - "3.6"
-    - "3.7"
-    - "3.8"
+  cache:
+    directories:
+      - ${PYENV_ROOT}
 
 jobs:
   include:
     - name: "Lint and check formatting"
-      <<: *linux_setup
-      dist: xenial
+      os: linux
+      language: python
+      python:
+        - "3.6"
       before_install:
         - pyenv global 3.6.7
       addons:
@@ -77,14 +64,14 @@ jobs:
       <<: *osx_setup
       osx_image: xcode8.0
       env:
-        - *env_osx_openssl
+        - *env_osx
         - CACHE_NAME="osx.el_capitan"
 
     - name: "OSX 10.12 - Sierra"
       <<: *osx_setup
       osx_image: xcode9.2
       env:
-        - *env_osx_openssl
+        - *env_osx
         - CACHE_NAME="osx.sierra"
         # OSX 10.12 Sierra frequently flakes when running with Pantsd. Restore the
         # original tests once https://github.com/pantsbuild/pants/issues/6714 and
@@ -95,28 +82,25 @@ jobs:
       <<: *osx_setup
       osx_image: xcode9.4
       env:
-        - *env_osx_openssl
+        - *env_osx
         - CACHE_NAME="osx.high_sierra"
 
     - name: "OSX 10.14 - Mojave"
       <<: *osx_setup
       osx_image: xcode11.3
       env:
-        - *env_osx_openssl
+        - *env_osx
         - CACHE_NAME="osx.mojave"
 
-    - name: "Ubuntu 16.04 - Xenial"
-      <<: *linux_setup
-      dist: xenial
-      env:
-        - CACHE_NAME="linux.xenial"
-        - SKIP_PYTHON38_TESTS=true
-      before_install:
-        - pyenv global 2.7.15 3.6.7 3.7.1
-
     - name: "Ubuntu 18.04 - Bionic"
-      <<: *linux_setup
+      os: linux
       dist: bionic
+      language: python
+      python:
+        - "2.7"
+        - "3.6"
+        - "3.7"
+        - "3.8"
       env:
         - CACHE_NAME="linux.bionic"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ env:
     - PYENV_PY27_VERSION=2.7.17
     - PYENV_PY36_VERSION=3.6.10
     - PYENV_PY37_VERSION=3.7.6
+    - PYENV_PY38_VERSION=3.8.1
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
 
 install:
   - pip install tox
@@ -41,7 +43,7 @@ osx_setup: &osx_setup
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
-    - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}"
+    - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}" "${PYENV_PY38_VERSION}"
   before_script:
     # Override file handler and thread limits
     - ulimit -c unlimited
@@ -55,6 +57,7 @@ linux_setup: &linux_setup
     - "2.7"
     - "3.6"
     - "3.7"
+    - "3.8"
 
 jobs:
   include:
@@ -102,20 +105,12 @@ jobs:
         - *env_osx_openssl
         - CACHE_NAME="osx.mojave"
 
-    - name: "Ubuntu 14.04 - Trusty"
-      <<: *linux_setup
-      dist: trusty
-      env:
-        - CACHE_NAME="linux.trusty"
-        - SKIP_PYTHON37_TESTS=true
-      before_install:
-        - pyenv global 2.7.14 3.6.3
-
     - name: "Ubuntu 16.04 - Xenial"
       <<: *linux_setup
       dist: xenial
       env:
         - CACHE_NAME="linux.xenial"
+        - SKIP_PYTHON38_TESTS=true
       before_install:
         - pyenv global 2.7.15 3.6.7 3.7.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ branches:
   only:
     - gh-pages
 
+language: python
+os: linux
+
 install:
   - pip install tox
 
@@ -19,12 +22,9 @@ osx_setup: &osx_setup
         - openssl
   env:
     - &env_osx >
-      # These flags are necessary to get OpenSSL working on OSX. See
-      # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
-      # We use Pyenv to install all the required Python versions.
       PYENV_PY27_VERSION=2.7.17
       PYENV_PY36_VERSION=3.6.10
       PYENV_PY37_VERSION=3.7.6
@@ -47,8 +47,6 @@ osx_setup: &osx_setup
 jobs:
   include:
     - name: "Lint and check formatting"
-      os: linux
-      language: python
       python:
         - "3.6"
       before_install:
@@ -93,9 +91,7 @@ jobs:
         - CACHE_NAME="osx.mojave"
 
     - name: "Ubuntu 18.04 - Bionic"
-      os: linux
       dist: bionic
-      language: python
       python:
         - "2.7"
         - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,20 @@ branches:
   only:
     - gh-pages
 
+env:
+  global:
+    - PYENV_PY27_VERSION=2.7.17
+    - PYENV_PY36_VERSION=3.6.10
+    - PYENV_PY37_VERSION=3.7.6
+    - PYENV_PY38_VERSION=3.8.1
+    # NB: Linux shards use Pyenv to pre-install Python. We must not override
+    # PYENV_ROOT on those shards, or their Python will no longer work.
+    - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
+
 language: python
 os: linux
 
@@ -21,19 +35,12 @@ osx_setup: &osx_setup
       packages:
         - openssl
   env:
-    - &env_osx >
+    # These flags are necessary to get OpenSSL working on OSX. See
+    # https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib.
+    - &env_osx_openssl >
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
-      PYENV_PY27_VERSION=2.7.17
-      PYENV_PY36_VERSION=3.6.10
-      PYENV_PY37_VERSION=3.7.6
-      PYENV_PY38_VERSION=3.8.1
-      PYENV_ROOT="${HOME}/.pants_pyenv}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
   before_install:
     - ./build-support/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}" "${PYENV_PY37_VERSION}" "${PYENV_PY38_VERSION}"
   before_script:
@@ -62,14 +69,14 @@ jobs:
       <<: *osx_setup
       osx_image: xcode8.0
       env:
-        - *env_osx
+        - *env_osx_openssl
         - CACHE_NAME="osx.el_capitan"
 
     - name: "OSX 10.12 - Sierra"
       <<: *osx_setup
       osx_image: xcode9.2
       env:
-        - *env_osx
+        - *env_osx_openssl
         - CACHE_NAME="osx.sierra"
         # OSX 10.12 Sierra frequently flakes when running with Pantsd. Restore the
         # original tests once https://github.com/pantsbuild/pants/issues/6714 and
@@ -80,14 +87,14 @@ jobs:
       <<: *osx_setup
       osx_image: xcode9.4
       env:
-        - *env_osx
+        - *env_osx_openssl
         - CACHE_NAME="osx.high_sierra"
 
     - name: "OSX 10.14 - Mojave"
       <<: *osx_setup
       osx_image: xcode11.3
       env:
-        - *env_osx
+        - *env_osx_openssl
         - CACHE_NAME="osx.mojave"
 
     - name: "Ubuntu 18.04 - Bionic"
@@ -97,7 +104,5 @@ jobs:
         - "3.6"
         - "3.7"
         - "3.8"
-      env:
-        - CACHE_NAME="linux.bionic"
       before_install:
         - pyenv global 2.7.17 3.6.9 3.7.5 3.8.0

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -35,14 +35,14 @@ class TestSanityCheck(TestBase):
         self, *python_versions: str, pants_version: Optional[str]
     ) -> None:
         for python_version in python_versions:
-            if "SKIP_PYTHON37_TESTS" in os.environ and python_version == "3.7":
+            if "SKIP_PYTHON38_TESTS" in os.environ and python_version == "3.8":
                 continue
             self.sanity_check(pants_version=pants_version, python_version=python_version)
 
     def test_pants_1_24(self) -> None:
         self.sanity_check(python_version=None, pants_version="1.24.0")
-        self.check_for_all_python_versions("3.6", "3.7", pants_version="1.24.0")
+        self.check_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.24.0")
 
     def test_pants_latest(self) -> None:
         self.sanity_check(python_version=None, pants_version=None)
-        self.check_for_all_python_versions("3.6", "3.7", pants_version=None)
+        self.check_for_all_python_versions("3.6", "3.7", "3.8", pants_version=None)

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -35,8 +35,6 @@ class TestSanityCheck(TestBase):
         self, *python_versions: str, pants_version: Optional[str]
     ) -> None:
         for python_version in python_versions:
-            if "SKIP_PYTHON38_TESTS" in os.environ and python_version == "3.8":
-                continue
             self.sanity_check(pants_version=pants_version, python_version=python_version)
 
     def test_pants_1_24(self) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ commands =
     pytest -v {posargs}
 passenv =
     SKIP_PANTSD_TESTS
-    SKIP_PYTHON38_TESTS
     # These are to support directing test environments to the correct OpenSSL on OSX.
     LDFLAGS
     CPPFLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     pytest -v {posargs}
 passenv =
     SKIP_PANTSD_TESTS
-    SKIP_PYTHON37_TESTS
+    SKIP_PYTHON38_TESTS
     # These are to support directing test environments to the correct OpenSSL on OSX.
     LDFLAGS
     CPPFLAGS


### PR DESCRIPTION
We claim that Pants works with Python 3.8. We should, therefore, test this.

As part of this change, we remove Ubuntu Trusty and Ubuntu Xenial to only use Ubuntu Bionic, as neither of those come with Python 3.8 by default.