### PR TITLE
Add support for `pants.toml`

### DIFF
--- a/pants
+++ b/pants
@@ -51,15 +51,20 @@ function get_exe_path_or_die {
   fi
 }
 
-function get_pants_ini_config_value {
-  if [[ ! -f 'pants.ini' ]]; then
-    return 0
-  fi
+function get_pants_config_value {
   config_key="$1"
-  valid_delimiters="[:=]"
   optional_space="[[:space:]]*"
-  prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-  sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
+  if [[ -f 'pants.ini' ]]; then
+    valid_delimiters="[:=]"
+    prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
+    sed -ne "/${prefix}/ s#${prefix}##p" pants.ini && return 0
+  fi
+  if [[ -f 'pants.toml' ]]; then
+    prefix="^${config_key}${optional_space}=${optional_space}"
+    raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" pants.toml)"
+    echo "${raw_value}"  | tr -d \"\' && return 0
+  fi
+  return 0
 }
 
 function get_python_major_minor_version {
@@ -84,7 +89,7 @@ EOF
 # are installed and up to date.
 
 function determine_pants_version {
-  pants_version="$(get_pants_ini_config_value 'pants_version')"
+  pants_version="$(get_pants_config_value 'pants_version')"
   if [[ -z "${pants_version}" ]]; then
     pants_version="$(curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
       python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])")"

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -52,7 +52,7 @@ class TestFirstTimeInstall(TestBase):
 
     def test_pants_1_16_and_earlier_fails(self) -> None:
         with self.setup_pants_in_tmpdir() as tmpdir:
-            self.create_pants_ini(parent_folder=tmpdir, pants_version="1.16.0")
+            self.create_pants_config(parent_folder=tmpdir, pants_version="1.16.0", use_toml=False)
             result = subprocess.run(
                 ["./pants", "--version"], cwd=tmpdir, stderr=subprocess.PIPE, encoding="utf-8"
             )

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -11,14 +11,18 @@ from test_base import TestBase
 
 
 class TestSanityCheck(TestBase):
-    def sanity_check(self, *, pants_version: Optional[str], python_version: Optional[str]) -> None:
+    def sanity_check(
+        self, *, pants_version: Optional[str], python_version: Optional[str], use_toml: bool = True
+    ) -> None:
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
 
         with self.setup_pants_in_tmpdir() as tmpdir, self.maybe_run_pyenv_local(
             python_version, parent_folder=tmpdir
         ):
-            self.create_pants_ini(parent_folder=tmpdir, pants_version=pants_version)
+            self.create_pants_config(
+                parent_folder=tmpdir, pants_version=pants_version, use_toml=use_toml
+            )
             self.create_dummy_build(parent_folder=tmpdir)
 
             def run_command(command: List[str], **kwargs: Any) -> None:
@@ -32,17 +36,20 @@ class TestSanityCheck(TestBase):
                 run_command(list_command, env=env_with_pantsd)
 
     def check_for_all_python_versions(
-        self, *python_versions: str, pants_version: Optional[str]
+        self, *python_versions: str, pants_version: Optional[str], use_toml: bool = True
     ) -> None:
         for python_version in python_versions:
             if "SKIP_PYTHON37_TESTS" in os.environ and python_version == "3.7":
                 continue
-            self.sanity_check(pants_version=pants_version, python_version=python_version)
+            self.sanity_check(
+                pants_version=pants_version, python_version=python_version, use_toml=use_toml
+            )
 
-    def test_pants_1_24(self) -> None:
-        self.sanity_check(python_version=None, pants_version="1.24.0")
-        self.check_for_all_python_versions("3.6", "3.7", pants_version="1.24.0")
+    def test_pants_latest_stable(self) -> None:
+        self.sanity_check(python_version=None, pants_version=None, use_toml=False)
+        self.check_for_all_python_versions("3.6", "3.7", pants_version=None, use_toml=False)
 
-    def test_pants_latest(self) -> None:
-        self.sanity_check(python_version=None, pants_version=None)
-        self.check_for_all_python_versions("3.6", "3.7", pants_version=None)
+    # NB: the first release series to support TOML config files.
+    def test_pants_1_26(self) -> None:
+        self.sanity_check(python_version=None, pants_version="1.26.0.dev0")
+        self.check_for_all_python_versions("3.6", "3.7", pants_version="1.26.0.dev0")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ basepython = python3
 [testenv:test]
 deps =
     pytest
+    toml
 commands =
     pytest -v {posargs}
 passenv =


### PR DESCRIPTION
Pants 1.26.x allows using `pants.toml` instead of `pants.ini`.