### PR TITLE
Bootstrap: disable progress bars when installing requirements with pip

### DIFF
--- a/pants
+++ b/pants
@@ -171,7 +171,7 @@ function bootstrap_pants {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install"
       "${staging_dir}/install/bin/pip" install -U pip
-      "${staging_dir}/install/bin/pip" install "${pants_requirement}"
+      "${staging_dir}/install/bin/pip" install --progress-bar off "${pants_requirement}"
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
       mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"
       green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."


### PR DESCRIPTION
CircleCI, and I suspect other CI services, act as TTY's 
http://man7.org/linux/man-pages/man3/isatty.3.html

This makes commands more likely to emit colorized text.

However, it also means that tools like pip emit progress bars, which can take up many lines. When a cache of the bootstrap is not available, it’s hard to navigate stdout.

This PR disables progress bars when downloading pants requirements with pip. I opted not to disable progress bars when upgrading pip itself (line 173), as the feature was only introduced in pip 10.0.0. An alternative there would be to use `--quite`, but that might have more of a negative ux impact, so leaving it to a different PR if it's desired.

Relevant slack discussion:
https://pantsbuild.slack.com/archives/C046T6T9U/p1590221925104100