### PR TITLE
Fix first_time test: make robust to warnings or other stderr

### DIFF
--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -39,7 +39,7 @@ def test_only_bootstraps_the_first_time(build_root: Path) -> None:
         encoding="utf-8",
         cwd=str(build_root),
     ).stderr
-    assert first_run_pants_script_logging
+    assert "Collecting pantsbuild.pants==" in first_run_pants_script_logging
     second_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -47,7 +47,7 @@ def test_only_bootstraps_the_first_time(build_root: Path) -> None:
         encoding="utf-8",
         cwd=str(build_root),
     ).stderr
-    assert not second_run_pants_script_logging
+    assert "Collecting pantsbuild.pants==" not in second_run_pants_script_logging
 
 
 def test_pants_1_16_and_earlier_fails(build_root: Path) -> None:


### PR DESCRIPTION
Currently, the `test_only_bootstraps_the_first_time` test is failing, as a result of brittleness to warnings and other textual output that is now present when pants runs.

It might be appropriate to update the configuration used when bootstrapping pants so that these warnings and messages are not present, but regardless I think updating the assertions here makes sense and is more future-proof.


Example of build failure:
https://travis-ci.com/github/pantsbuild/setup/jobs/339413866


Sidenote: it's unfortunate that this test broke due to changes in another repo. Might be a good argument for consolidating this setup code into the main pants repository.