### PR TITLE
Parameterize the config file name.

### DIFF
--- a/pants
+++ b/pants
@@ -55,6 +55,7 @@ function get_exe_path_or_die {
   fi
 }
 
+pants_config_file=""
 if [[ -f "${PANTS_INI}" ]]; then
   pants_config_file="${PANTS_INI}"
 fi
@@ -204,12 +205,16 @@ pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 export no_proxy='*'
 
-if [[ -z ${pants_config_file+x} ]]; then
+if [[ -z "${pants_config_file}" ]]; then
   pants_config_file_flag="";
 else
   pants_config_file_flag=--pants-config-files="[\"${PWD}/${pants_config_file}\"]";
 fi
 
-set -x
+# MacOS's default open files limit is too low for Pants, bump it to something reasonable.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  ulimit -n 10000
+fi
+
 exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" \
   "${pants_config_file_flag}" --pants-bin-name="${PANTS_BIN_NAME}" "$@"

--- a/pants
+++ b/pants
@@ -211,10 +211,5 @@ else
   pants_config_file_flag=--pants-config-files="[\"${PWD}/${pants_config_file}\"]";
 fi
 
-# MacOS's default open files limit is too low for Pants, bump it to something reasonable.
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  ulimit -n 10000
-fi
-
 exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" \
   "${pants_config_file_flag}" --pants-bin-name="${PANTS_BIN_NAME}" "$@"

--- a/pants
+++ b/pants
@@ -15,6 +15,10 @@ set -eou pipefail
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 
+PANTS_INI=${PANTS_INI:-pants.ini}
+PANTS_TOML=${PANTS_TOML:-pants.toml}
+PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
+
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
@@ -51,17 +55,24 @@ function get_exe_path_or_die {
   fi
 }
 
+if [[ -f "${PANTS_INI}" ]]; then
+  pants_config_file="${PANTS_INI}"
+fi
+if [[ -f "${PANTS_TOML}" ]]; then
+  pants_config_file="${PANTS_TOML}"
+fi
+
 function get_pants_config_value {
   config_key="$1"
   optional_space="[[:space:]]*"
-  if [[ -f 'pants.ini' ]]; then
+  if [[ "${pants_config_file}" == *.ini ]]; then
     valid_delimiters="[:=]"
     prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
-    sed -ne "/${prefix}/ s#${prefix}##p" pants.ini && return 0
+    sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_INI}" && return 0
   fi
-  if [[ -f 'pants.toml' ]]; then
+  if [[ "${pants_config_file}" == *.toml ]]; then
     prefix="^${config_key}${optional_space}=${optional_space}"
-    raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" pants.toml)"
+    raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
     echo "${raw_value}"  | tr -d \"\' && return 0
   fi
   return 0
@@ -79,7 +90,7 @@ EOF
 # The high-level flow:
 # 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
 #     then defaulting to Python 3.6+.
-# 2.) Resolve the Pants version from pants.ini or from the latest stable
+# 2.) Resolve the Pants version from config or from the latest stable
 #     release to PyPI, so that we know what to name the venv (virtual environment) folder and what
 #     to install with Pip.
 # 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
@@ -193,4 +204,12 @@ pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 export no_proxy='*'
 
-exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"
+if [[ -z ${pants_config_file+x} ]]; then
+  pants_config_file_flag="";
+else
+  pants_config_file_flag=--pants-config-files="[\"${PWD}/${pants_config_file}\"]";
+fi
+
+set -x
+exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" \
+  "${pants_config_file_flag}" --pants-bin-name="${PANTS_BIN_NAME}" "$@"

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -121,7 +121,6 @@ def test_pants_latest_stable(checker: SanityChecker) -> None:
     )
 
 
-# NB: the first release series to support TOML config files.
-def test_pants_1_26(checker: SanityChecker) -> None:
-    checker.sanity_check(python_version=None, pants_version="1.26.0.dev0")
-    checker.sanity_check_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.26.0.dev0")
+def test_pants_1_28(checker: SanityChecker) -> None:
+    checker.sanity_check(python_version=None, pants_version="1.28.0")
+    checker.sanity_check_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.28.0")


### PR DESCRIPTION
Instead of hardcoding pants.toml/pants.ini.

Allows the script to be shared for both
v2-only and v1-only invocations, by pointing
it at different config.

Also update a test to use pants 1.28.0. That test
no longer passed, even at unmodified HEAD, due to
some watchman issue. In any case, it's more important
to test against a recent pants, since people downloading
the script are likely to be doing so in order to run
the most recent stable release (which is what the setup
script will choose for them on first bootstrap).