### PR TITLE
Don't set the config file in the runner script

### DIFF
--- a/pants
+++ b/pants
@@ -15,8 +15,12 @@ set -eou pipefail
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 
+# Set these to specify where this script can read the pants version from.
+# This will also be passed to pants itself as its config file, unless the
+# PANTS_CONFIG_FILES var is already set, in which case we defer to that value.
 PANTS_INI=${PANTS_INI:-pants.ini}
 PANTS_TOML=${PANTS_TOML:-pants.toml}
+
 PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
 
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
@@ -205,11 +209,8 @@ pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 export no_proxy='*'
 
-if [[ -z "${pants_config_file}" ]]; then
-  pants_config_file_flag="";
-else
-  pants_config_file_flag=--pants-config-files="[\"${PWD}/${pants_config_file}\"]";
+if ! [[ -v PANTS_CONFIG_FILES ]] && [[ -n ${pants_config_file} ]]; then
+  export PANTS_CONFIG_FILES="[\"${PWD}/${pants_config_file}\"]";
 fi
 
-exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" \
-  "${pants_config_file_flag}" --pants-bin-name="${PANTS_BIN_NAME}" "$@"
+exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" --pants-bin-name="${PANTS_BIN_NAME}" "$@"

--- a/pants
+++ b/pants
@@ -15,9 +15,9 @@ set -eou pipefail
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 
-# Set these to specify where this script can read the pants version from.
-# This will also be passed to pants itself as its config file, unless the
-# PANTS_CONFIG_FILES var is already set, in which case we defer to that value.
+# Set one of these to specify a non-standard location for this script to read the pants version from.
+# NB: This will *not* cause Pants itself to use this location as a config file.
+#     You can use PANTS_CONFIG_FILES or --pants-config-files to do so.
 PANTS_INI=${PANTS_INI:-pants.ini}
 PANTS_TOML=${PANTS_TOML:-pants.toml}
 
@@ -208,9 +208,5 @@ pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
 #
 # See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
 export no_proxy='*'
-
-if ! [[ -v PANTS_CONFIG_FILES ]] && [[ -n ${pants_config_file} ]]; then
-  export PANTS_CONFIG_FILES="[\"${PWD}/${pants_config_file}\"]";
-fi
 
 exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" --pants-bin-name="${PANTS_BIN_NAME}" "$@"


### PR DESCRIPTION
PANTS_TOML/PANTS_INI are now only used by the script itself, to find the Pants version to bootstrap. If the user also wants Pants to use this as a config file, they must do so explicitly.