### PR TITLE
Allow $PANTS_HOME to be a relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pants setup
 
-This repository contains the bootstrap needed to get you up and running with pants.
+This repository contains the bootstrap needed to get you up and running with Pants.
 
-Follow the instructions at https://www.pantsbuild.org/install.
+Follow the instructions at https://www.pantsbuild.org/docs/installation.
 
 ### Development
 
@@ -18,4 +18,10 @@ You may run certain checks (`environments` in tox) with `tox -e` (run `tox -a` t
 $ tox -e format-run
 $ tox -e lint
 $ tox -e test
+```
+
+You may pass through arguments to Pytest:
+
+```bash
+$ tox -e test -- -vv -k test_only_bootstraps_the_first_time
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ tox -e lint
 $ tox -e test
 ```
 
-You may pass through arguments to Pytest:
+You may pass arguments to Pytest like this:
 
 ```bash
 $ tox -e test -- -vv -k test_only_bootstraps_the_first_time

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <title>Pants Setup</title>
-    <meta http-equiv="refresh" content="0; url=https://www.pantsbuild.org/install">
+    <meta http-equiv="refresh" content="0; url=https://www.pantsbuild.org/docs/installation">
   </head>
   <body>
     <p style="font-size:150%;">
-    Follow the instructions at <a href="https://www.pantsbuild.org/install">
-      https://www.pantsbuild.org/install</a> to setup Pants.
+    Follow the instructions at <a href="https://www.pantsbuild.org/docs/installation">
+      pantsbuild.org/docs/installation</a> to setup Pants.
     </p>
   </body>
 </html>

--- a/pants
+++ b/pants
@@ -118,11 +118,6 @@ function determine_pants_version {
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 16 ]]; then
-    die "This version of the \`./pants\` script does not work with Pants <= 1.16.0. Instead,
-either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
-https://raw.githubusercontent.com/pantsbuild/setup/3bb006e4a792ae83d7059ea76c0372ece7c1069d/pants."
-  fi
   if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 22 ]]; then
     die "This version of the \`./pants\` script does not work with Pants <= 1.22.0. Instead,
 either upgrade your \`pants_version\` or use the version of the \`./pants\` script at

--- a/pants
+++ b/pants
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # =============================== NOTE ===============================
@@ -26,6 +26,11 @@ PANTS_TOML=${PANTS_TOML:-pants.toml}
 PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
 
 PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+# If given a relative path, we fix it to be absolute.
+if [[ "$PANTS_HOME" != /* ]]; then
+  PANTS_HOME="${PWD}/${PANTS_HOME}"
+fi
+
 PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
 
 VENV_VERSION=${VENV_VERSION:-16.4.3}
@@ -116,8 +121,8 @@ function determine_pants_version {
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 16 ]]; then
-    die "This version of the \`./pants\` script does not work with Pants <= 1.16.0. Instead,
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -lt 23 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants < 1.23.0. Instead,
 either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
 https://raw.githubusercontent.com/pantsbuild/setup/3bb006e4a792ae83d7059ea76c0372ece7c1069d/pants."
   fi

--- a/pants
+++ b/pants
@@ -4,13 +4,10 @@
 
 # =============================== NOTE ===============================
 # This ./pants bootstrap script comes from the pantsbuild/setup
-# project and is intended to be checked into your code repository so
-# that any developer can check out your code and be building it with
-# Pants with no prior setup needed.
+# project. It is intended to be checked into your code repository so
+# that other developers have the same setup.
 #
-# It requires your version of pants to be v1.23.0 or newer.
-#
-# You can learn more here: https://pants.readme.io/docs/installation
+# Learn more here: https://www.pantsbuild.org/docs/installation
 # ====================================================================
 
 set -eou pipefail
@@ -121,10 +118,15 @@ function determine_pants_version {
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -lt 23 ]]; then
-    die "This version of the \`./pants\` script does not work with Pants < 1.23.0. Instead,
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 16 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.16.0. Instead,
 either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
 https://raw.githubusercontent.com/pantsbuild/setup/3bb006e4a792ae83d7059ea76c0372ece7c1069d/pants."
+  fi
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 22 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.22.0. Instead,
+either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
+https://raw.githubusercontent.com/pantsbuild/setup/d1da382f6de0420940ec6007a39cba87c21075c6/pants."
   fi
   echo "${pants_version}"
 }

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -67,15 +67,6 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
     )
 
 
-def test_pants_1_16_and_earlier_fails(build_root: Path) -> None:
-    create_pants_config(parent_folder=build_root, pants_version="1.16.0", use_toml=False)
-    result = subprocess.run(
-        ["./pants", "--version"], cwd=str(build_root), stderr=subprocess.PIPE, encoding="utf-8"
-    )
-    assert result.returncode != 0
-    assert "does not work with Pants <= 1.16.0" in result.stderr
-
-
 def test_pants_1_22_and_earlier_fails(build_root: Path) -> None:
     create_pants_config(parent_folder=build_root, pants_version="1.22.0", use_toml=False)
     result = subprocess.run(

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -58,7 +58,7 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
         stderr=subprocess.PIPE,
         encoding="utf-8",
         cwd=str(build_root),
-        env={"PANTS_HOME": "relative_dir"},
+        env={**os.environ, "PANTS_HOME": "relative_dir"},
     )
     assert re.search(
         r"virtual environment successfully created at .*/relative_dir/bootstrap.*/",
@@ -67,13 +67,22 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
     )
 
 
+def test_pants_1_16_and_earlier_fails(build_root: Path) -> None:
+    create_pants_config(parent_folder=build_root, pants_version="1.16.0", use_toml=False)
+    result = subprocess.run(
+        ["./pants", "--version"], cwd=str(build_root), stderr=subprocess.PIPE, encoding="utf-8"
+    )
+    assert result.returncode != 0
+    assert "does not work with Pants <= 1.16.0" in result.stderr
+
+
 def test_pants_1_22_and_earlier_fails(build_root: Path) -> None:
     create_pants_config(parent_folder=build_root, pants_version="1.22.0", use_toml=False)
     result = subprocess.run(
         ["./pants", "--version"], cwd=str(build_root), stderr=subprocess.PIPE, encoding="utf-8"
     )
     assert result.returncode != 0
-    assert "does not work with Pants < 1.23.0" in result.stderr
+    assert "does not work with Pants <= 1.22.0" in result.stderr
 
 
 def test_python2_fails(build_root: Path) -> None:

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -37,7 +37,7 @@ def pyenv_versions(pyenv_bin: str) -> List[str]:
 
 
 @dataclass(frozen=True)
-class SanityChecker:
+class SmokeTester:
     pyenv_bin: str
     pyenv_versions: List[str]
     build_root: Path
@@ -79,7 +79,7 @@ class SanityChecker:
                 check=True,
             )
 
-    def sanity_check(
+    def smoke_test(
         self, *, pants_version: Optional[str], python_version: Optional[str], use_toml: bool = True
     ) -> None:
         version_command = ["./pants", "--version"]
@@ -100,27 +100,27 @@ class SanityChecker:
                 run_command(version_command, env=env_with_pantsd)
                 run_command(list_command, env=env_with_pantsd)
 
-    def sanity_check_for_all_python_versions(
+    def smoke_test_for_all_python_versions(
         self, *python_versions: str, pants_version: Optional[str], use_toml: bool = True
     ) -> None:
         for python_version in python_versions:
-            self.sanity_check(
+            self.smoke_test(
                 pants_version=pants_version, python_version=python_version, use_toml=use_toml
             )
 
 
 @pytest.fixture
-def checker(pyenv_bin: str, pyenv_versions: List[str], build_root: Path) -> SanityChecker:
-    return SanityChecker(pyenv_bin=pyenv_bin, pyenv_versions=pyenv_versions, build_root=build_root)
+def checker(pyenv_bin: str, pyenv_versions: List[str], build_root: Path) -> SmokeTester:
+    return SmokeTester(pyenv_bin=pyenv_bin, pyenv_versions=pyenv_versions, build_root=build_root)
 
 
-def test_pants_latest_stable(checker: SanityChecker) -> None:
-    checker.sanity_check(python_version=None, pants_version=None, use_toml=False)
-    checker.sanity_check_for_all_python_versions(
+def test_pants_latest_stable(checker: SmokeTester) -> None:
+    checker.smoke_test(python_version=None, pants_version=None, use_toml=False)
+    checker.smoke_test_for_all_python_versions(
         "3.6", "3.7", "3.8", pants_version=None, use_toml=False
     )
 
 
-def test_pants_1_28(checker: SanityChecker) -> None:
-    checker.sanity_check(python_version=None, pants_version="1.28.0")
-    checker.sanity_check_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.28.0")
+def test_pants_1_28(checker: SmokeTester) -> None:
+    checker.smoke_test(python_version=None, pants_version="1.28.0")
+    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.28.0")


### PR DESCRIPTION
A user requested this because their CI provider GitLab works better with relative paths than absolute paths. Generally, Pants allows relative paths, so it's consistent for us to support them here, too.

This also makes some other improvements:
* Fix our version check to look for >= 1.23, rather than > 1.16. This has been the case, but we didn't change the version check.
* Use the more inclusive term `smoke screen`.