### PR TITLE
Require `pants_version` to be set

### DIFF
--- a/pants
+++ b/pants
@@ -105,9 +105,8 @@ EOF
 # The high-level flow:
 # 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
 #     then defaulting to Python 3.6+.
-# 2.) Resolve the Pants version from config or from the latest stable
-#     release to PyPI, so that we know what to name the venv (virtual environment) folder and what
-#     to install with Pip.
+# 2.) Resolve the Pants version from config so that we know what to name the venv
+#     (virtual environment) folder and what to install with Pip.
 # 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
 # 4.) Execute Pants with the resolved Python interpreter and venv.
 #
@@ -126,8 +125,9 @@ function determine_pants_version {
 
   pants_version="$(get_pants_config_value 'pants_version')"
   if [[ -z "${pants_version}" ]]; then
-    pants_version="$(curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
-      "${python}" -c "import json, sys; print(json.load(sys.stdin)['info']['version'])")"
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the
+\`[GLOBAL]\` scope. See https://pypi.org/project/pantsbuild.pants/#history for all released
+versions and https://www.pantsbuild.org/docs/installation for more instructions."
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,36 +3,24 @@
 
 import configparser
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import toml
 
 
-def create_pants_config(
-    *, parent_folder: Path, pants_version: Optional[str], use_toml: bool = True
-) -> None:
+def create_pants_config(*, parent_folder: Path, pants_version: str, use_toml: bool = True) -> None:
+    global_section: Dict[str, Any] = {
+        "pants_version": pants_version,
+        "backend_packages": ["pants.backend.python"],
+    }
     # NB: string comparison is not always correct for semvers, but it works in the
     #  cases we care about for testing.
-    no_plugin = pants_version and pants_version >= "1.29"
-    global_section: Dict[str, Any] = {"backend_packages": ["pants.backend.python"]}
-    if pants_version:
-        global_section["pants_version"] = pants_version
-    if not no_plugin:
-        global_section["plugins"] = (
-            ["pantsbuild.pants.contrib.go==%(pants_version)s"]
-            if pants_version
-            else ["pantsbuild.pants.contrib.go"]
-        )
+    if pants_version <= "1.28":
+        global_section["plugins"] = ["pantsbuild.pants.contrib.go==%(pants_version)s"]
 
     if use_toml:
-        config = {"GLOBAL": global_section}
-        # TODO: string interpolation does not work for TOML when the value comes from the same
-        #  section. This is fixed in Pants 1.26.0.dev1+.
-        if pants_version is not None:
-            config["GLOBAL"].pop("pants_version")
-            config["DEFAULT"] = {"pants_version": pants_version}
         with (parent_folder / "pants.toml").open("w") as f:
-            toml.dump(config, f)
+            toml.dump({"GLOBAL": global_section}, f)
     else:
         cp = configparser.ConfigParser()
         cp["GLOBAL"] = global_section

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -12,26 +12,8 @@ from pathlib import Path
 from helpers import create_pants_config
 
 
-def test_venv_name_uses_most_recent_stable_release(build_root: Path) -> None:
-    result = subprocess.run(
-        ["./pants", "--version"],
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf-8",
-        cwd=str(build_root),
-    )
-    # Pip will resolve the most recent stable release, which will be the output of
-    # `./pants --version`.
-    downloaded_version = result.stdout.strip()
-    assert re.search(
-        fr"virtual environment successfully created at .*/bootstrap.*/{downloaded_version}_py",
-        result.stderr,
-        flags=re.MULTILINE,
-    )
-
-
 def test_only_bootstraps_the_first_time(build_root: Path) -> None:
+    create_pants_config(parent_folder=build_root, pants_version="1.30.1")
     first_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -51,6 +33,7 @@ def test_only_bootstraps_the_first_time(build_root: Path) -> None:
 
 
 def test_relative_cache_locations_work(build_root: Path) -> None:
+    create_pants_config(parent_folder=build_root, pants_version="1.30.1")
     result = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -76,7 +59,20 @@ def test_pants_1_22_and_earlier_fails(build_root: Path) -> None:
     assert "does not work with Pants <= 1.22.0" in result.stderr
 
 
+def test_pants_version_must_be_set(build_root: Path) -> None:
+    # We do not call `create_pants_config()`.
+    result = subprocess.run(
+        ["./pants", "--version"],
+        cwd=str(build_root),
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    assert result.returncode != 0
+    assert "Please explicitly specify the `pants_version` in your `pants.toml`" in result.stderr
+
+
 def test_python2_fails(build_root: Path) -> None:
+    create_pants_config(parent_folder=build_root, pants_version="1.30.1")
     result = subprocess.run(
         ["./pants", "--version"],
         cwd=str(build_root),

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -123,7 +123,7 @@ class SmokeTester:
                 run_command(binary_command, env=env_with_pantsd)
 
     def smoke_test_for_all_python_versions(
-        self, *python_versions: str, pants_version: Optional[str], use_toml: bool = True
+        self, *python_versions: str, pants_version: str, use_toml: bool = True
     ) -> None:
         for python_version in python_versions:
             self.smoke_test(

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -83,7 +83,7 @@ class SmokeTester:
     def smoke_test(
         self,
         *,
-        pants_version: Optional[str],
+        pants_version: str,
         python_version: Optional[str],
         use_toml: bool = True,
         sha: Optional[str] = None,
@@ -136,21 +136,14 @@ def checker(pyenv_bin: str, pyenv_versions: List[str], build_root: Path) -> Smok
     return SmokeTester(pyenv_bin=pyenv_bin, pyenv_versions=pyenv_versions, build_root=build_root)
 
 
-def test_pants_latest_stable(checker: SmokeTester) -> None:
-    checker.smoke_test(python_version=None, pants_version=None, use_toml=False)
-    checker.smoke_test_for_all_python_versions(
-        "3.6", "3.7", "3.8", pants_version=None, use_toml=False
-    )
-
-
 def test_pants_1_28(checker: SmokeTester) -> None:
     checker.smoke_test(python_version=None, pants_version="1.28.0")
     checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.28.0")
 
 
 def test_pants_2_0(checker: SmokeTester) -> None:
-    checker.smoke_test(python_version=None, pants_version="2.0.0.dev6")
-    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="2.0.0.dev6")
+    checker.smoke_test(python_version=None, pants_version="2.0.0b1")
+    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="2.0.0b1")
 
 
 def test_pants_at_sha(checker: SmokeTester) -> None:


### PR DESCRIPTION
We generally highly encourage users to use lockfiles because it's important for deterministic builds. But with the Pants script itself, we did not require this determinism, which could result in builds breaking randomly when we do new stable releases.

Our docs already have been saying to set the `pants_version` before running `./pants`, so we don't need to update anything there.