### PR TITLE
Rename `PANTS_HOME` to `PANTS_SETUP_CACHE`

### DIFF
--- a/pants
+++ b/pants
@@ -28,13 +28,13 @@ PANTS_TOML=${PANTS_TOML:-pants.toml}
 
 PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
 
-PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+PANTS_SETUP_CACHE="${PANTS_SETUP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
 # If given a relative path, we fix it to be absolute.
-if [[ "$PANTS_HOME" != /* ]]; then
-  PANTS_HOME="${PWD}/${PANTS_HOME}"
+if [[ "$PANTS_SETUP_CACHE" != /* ]]; then
+  PANTS_SETUP_CACHE="${PWD}/${PANTS_SETUP_CACHE}"
 fi
 
-PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
+PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
 VENV_VERSION=${VENV_VERSION:-16.4.3}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ class MonkeyPatch(Protocol):
 
 @pytest.fixture
 def build_root(project_root: PurePath, tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
-    monkeypatch.setenv("PANTS_HOME", str(tmp_path / "PANTS_HOME"))
+    monkeypatch.setenv("PANTS_SETUP_CACHE", str(tmp_path / "PANTS_SETUP_CACHE"))
 
     # NB: Unlike the install guide's instruction to curl the `./pants` script, we directly
     # copy it to ensure we are using the branch's version of the script and to avoid

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -41,7 +41,7 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
         stderr=subprocess.PIPE,
         encoding="utf-8",
         cwd=str(build_root),
-        env={**os.environ, "PANTS_HOME": "relative_dir"},
+        env={**os.environ, "PANTS_SETUP_CACHE": "relative_dir"},
     )
     assert re.search(
         r"virtual environment successfully created at .*/relative_dir/bootstrap.*/",


### PR DESCRIPTION
This is more descriptive. See https://www.pantsbuild.org/docs/troubleshooting#how-to-change-your-cache-directory for where we discuss caching locations; we already have 4 directories Pants writes to, so we need a way to disambiguate what this particular value is for.