### PR TITLE
Hotfix CI failure from removing pants.ini support

### DIFF
--- a/pants
+++ b/pants
@@ -115,10 +115,11 @@ versions and https://www.pantsbuild.org/docs/installation for more instructions.
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
-  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 22 ]]; then
-    die "This version of the \`./pants\` script does not work with Pants <= 1.22.0. Instead,
-either upgrade your \`pants_version\` or use the version of the \`./pants\` script at
-https://raw.githubusercontent.com/pantsbuild/setup/d1da382f6de0420940ec6007a39cba87c21075c6/pants."
+  # 1.26 is the first version to support `pants.toml`, so we fail eagerly if using an outdated version.
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 25 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.25.0 (and it also requires using \`pants.toml\`,
+rather than \`pants.ini\`). Instead, either upgrade your \`pants_version\` or use the version of the \`./pants\` script
+at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db70810e38f050b0a268/pants."
   fi
   echo "${pants_version}"
 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,14 +1,13 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import configparser
 from pathlib import Path
 from typing import Any, Dict
 
 import toml
 
 
-def create_pants_config(*, parent_folder: Path, pants_version: str, use_toml: bool = True) -> None:
+def create_pants_config(*, parent_folder: Path, pants_version: str) -> None:
     global_section: Dict[str, Any] = {
         "pants_version": pants_version,
         "backend_packages": ["pants.backend.python"],
@@ -18,11 +17,5 @@ def create_pants_config(*, parent_folder: Path, pants_version: str, use_toml: bo
     if pants_version <= "1.28":
         global_section["plugins"] = ["pantsbuild.pants.contrib.go==%(pants_version)s"]
 
-    if use_toml:
-        with (parent_folder / "pants.toml").open("w") as f:
-            toml.dump({"GLOBAL": global_section}, f)
-    else:
-        cp = configparser.ConfigParser()
-        cp["GLOBAL"] = global_section
-        with (parent_folder / "pants.ini").open("w") as f:
-            cp.write(f)
+    with (parent_folder / "pants.toml").open("w") as f:
+        toml.dump({"GLOBAL": global_section}, f)

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -50,13 +50,13 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
     )
 
 
-def test_pants_1_22_and_earlier_fails(build_root: Path) -> None:
-    create_pants_config(parent_folder=build_root, pants_version="1.22.0", use_toml=False)
+def test_pants_1_25_and_earlier_fails(build_root: Path) -> None:
+    create_pants_config(parent_folder=build_root, pants_version="1.25.0")
     result = subprocess.run(
         ["./pants", "--version"], cwd=str(build_root), stderr=subprocess.PIPE, encoding="utf-8"
     )
     assert result.returncode != 0
-    assert "does not work with Pants <= 1.22.0" in result.stderr
+    assert "does not work with Pants <= 1.25.0" in result.stderr
 
 
 def test_pants_version_must_be_set(build_root: Path) -> None:

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -85,7 +85,6 @@ class SmokeTester:
         *,
         pants_version: str,
         python_version: Optional[str],
-        use_toml: bool = True,
         sha: Optional[str] = None,
     ) -> None:
         env = {**os.environ}
@@ -95,18 +94,16 @@ class SmokeTester:
         list_command = ["./pants", "list", "::"]
         binary_command = ["./pants", "binary", "//:bin"]
         with self._maybe_run_pyenv_local(python_version):
-            create_pants_config(
-                parent_folder=self.build_root, pants_version=pants_version, use_toml=use_toml
-            )
+            create_pants_config(parent_folder=self.build_root, pants_version=pants_version)
             (self.build_root / "BUILD").write_text(
                 textwrap.dedent(
                     """
-            target(name='test')
+                    target(name='test')
 
-            # To test that we can resolve these, esp. against custom shas.
-            pants_requirement(name='pantsreq')
-            python_binary(name='bin', dependencies=[':pantsreq'], entry_point='dummy')
-            """
+                    # To test that we can resolve these, esp. against custom shas.
+                    pants_requirement(name='pantsreq')
+                    python_binary(name='bin', dependencies=[':pantsreq'], entry_point='dummy')
+                    """
                 )
             )
 
@@ -122,13 +119,9 @@ class SmokeTester:
                 run_command(list_command, env=env_with_pantsd)
                 run_command(binary_command, env=env_with_pantsd)
 
-    def smoke_test_for_all_python_versions(
-        self, *python_versions: str, pants_version: str, use_toml: bool = True
-    ) -> None:
+    def smoke_test_for_all_python_versions(self, *python_versions: str, pants_version: str) -> None:
         for python_version in python_versions:
-            self.smoke_test(
-                pants_version=pants_version, python_version=python_version, use_toml=use_toml
-            )
+            self.smoke_test(pants_version=pants_version, python_version=python_version)
 
 
 @pytest.fixture


### PR DESCRIPTION
For some reason, CI didn't trigger on https://github.com/pantsbuild/setup/pull/88.

This also updates our check for using outdated Pants versions to require the first version to support `pants.toml`: 1.26.