### PR TITLE
Pants 2.2 will no longer run with Python 3.6

### DIFF
--- a/pants
+++ b/pants
@@ -6,7 +6,6 @@
 # This ./pants bootstrap script comes from the pantsbuild/setup
 # project. It is intended to be checked into your code repository so
 # that other developers have the same setup.
-
 #
 # Learn more here: https://www.pantsbuild.org/docs/installation
 # ====================================================================
@@ -62,23 +61,24 @@ function tempdir {
 }
 
 function get_exe_path_or_die {
-  exe="$1"
+  local exe="$1"
   if ! command -v "${exe}"; then
     die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
   fi
 }
 
 function get_pants_config_value {
-  config_key="$1"
-  optional_space="[[:space:]]*"
-  prefix="^${config_key}${optional_space}=${optional_space}"
+  local config_key="$1"
+  local optional_space="[[:space:]]*"
+  local prefix="^${config_key}${optional_space}=${optional_space}"
+  local raw_value
   raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
   echo "${raw_value}"  | tr -d \"\' && return 0
   return 0
 }
 
 function get_python_major_minor_version {
-  python_exe="$1"
+  local python_exe="$1"
   "$python_exe" <<EOF
 import sys
 major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
@@ -87,10 +87,11 @@ EOF
 }
 
 # The high-level flow:
-# 1.) Resolve the Python interpreter, first reading from the env var $PYTHON,
-#     then defaulting to Python 3.6+.
-# 2.) Resolve the Pants version from config so that we know what to name the venv
-#     (virtual environment) folder and what to install with Pip.
+#
+# 1.) Resolve the Pants version from config so that we know what interpreters we can use, what to name the venv,
+#     and what to install via pip.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON, then using a default based on the Pants
+#     version.
 # 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
 # 4.) Execute Pants with the resolved Python interpreter and venv.
 #
@@ -98,14 +99,11 @@ EOF
 # are installed and up to date.
 
 function determine_pants_version {
-
   if [ -n "${PANTS_SHA:-}" ]; then
     # get_version_for_sha will echo the version, thus "returning" it from this function.
     get_version_for_sha "$PANTS_SHA"
     return
   fi
-
-  python="$1"
 
   pants_version="$(get_pants_config_value 'pants_version')"
   if [[ -z "${pants_version}" ]]; then
@@ -124,8 +122,34 @@ at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db7
   echo "${pants_version}"
 }
 
+function set_supported_python_versions {
+  local pants_version="$1"
+  local pants_major_version
+  local pants_minor_version
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 0 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.7' '3.8' '3.6')
+    supported_python_versions_int=('37' '38' '36')
+    supported_message='3.7, 3.8, or 3.6 (deprecated)'
+  else
+    supported_python_versions_decimal=('3.7' '3.8')
+    supported_python_versions_int=('37' '38')
+    supported_message='3.7 or 3.8'
+  fi
+}
+
 function determine_default_python_exe {
-  for version in '3.6' '3.7' '3.8' '3.9'; do
+  for version in "${supported_python_versions_decimal[@]}"; do
+    local interpreter_path
     interpreter_path="$(command -v "python${version}")"
     if [[ -z "${interpreter_path}" ]]; then
       continue
@@ -136,25 +160,33 @@ function determine_default_python_exe {
     fi
     echo "${interpreter_path}" && return 0
   done
+  die "No valid Python interpreter found. "
 }
 
 function determine_python_exe {
+  local pants_version="$1"
+  set_supported_python_versions "${pants_version}"
+  local requirement_str="For \`pants_version = \"${pants_version}\"\`, Pants requires Python ${supported_message} to run."
+
+  local python_bin_name
   if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
     python_bin_name="${PYTHON_BIN_NAME}"
   else
     python_bin_name="$(determine_default_python_exe)"
     if [[ -z "${python_bin_name}" ]]; then
-      die "No valid Python interpreter found. Pants requires Python 3.6+ to run."
+      die "No valid Python interpreter found. ${requirement_str}"
     fi
   fi
+  local python_exe
   python_exe="$(get_exe_path_or_die "${python_bin_name}")"
+  local major_minor_version
   major_minor_version="$(get_python_major_minor_version "${python_exe}")"
-  for valid_version in '36' '37' '38' '39'; do
+  for valid_version in "${supported_python_versions_int[@]}"; do
     if [[ "${major_minor_version}" == "${valid_version}" ]]; then
       echo "${python_exe}" && return 0
     fi
   done
-  die "Invalid Python interpreter version for ${python_exe}. Pants requires Python 3.6+ to run."
+  die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
 }
 
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
@@ -164,6 +196,7 @@ function bootstrap_venv {
   if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]; then
     (
       mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       cd "${staging_dir}"
       curl -LO "https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}"
@@ -178,7 +211,6 @@ function bootstrap_venv {
 function find_links_url {
   local pants_version="$1"
   local pants_sha="$2"
-
   echo -n "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/${pants_sha}/${pants_version/+/%2B}/index.html"
 }
 
@@ -195,22 +227,27 @@ function get_version_for_sha {
 }
 
 function bootstrap_pants {
-  pants_version="$1"
-  python="$2"
-  pants_sha="${3:-}"
+  local pants_version="$1"
+  local python="$2"
+  local pants_sha="${3:-}"
 
-  pants_requirement="pantsbuild.pants==${pants_version}"
+  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local maybe_find_links
   if [[ -z "${pants_sha}" ]]; then
     maybe_find_links=""
   else
     maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
    fi
+  local python_major_minor_version
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  local target_folder_name
   target_folder_name="${pants_version}_py${python_major_minor_version}"
 
   if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
     (
+      local venv_path
       venv_path="$(bootstrap_venv)"
+      local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       # shellcheck disable=SC2086
       "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install" && \
@@ -226,8 +263,8 @@ function bootstrap_pants {
 
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-python="$(determine_python_exe)"
-pants_version="$(determine_pants_version "${python}")"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
 pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")"
 pants_python="${pants_dir}/bin/python"
 pants_binary="${pants_dir}/bin/pants"

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -81,4 +81,8 @@ def test_python2_fails(build_root: Path) -> None:
         env={**os.environ, "PYTHON": "python2"},
     )
     assert result.returncode != 0
-    assert "Pants requires Python 3.6+ to run" in result.stderr
+    # For 1.30.x, we expect this message.
+    assert (
+        'For `pants_version = "1.30.1"`, Pants requires Python 3.6, 3.7, or 3.8 to run.'
+        in result.stderr
+    )

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -81,7 +81,6 @@ def test_python2_fails(build_root: Path) -> None:
         env={**os.environ, "PYTHON": "python2"},
     )
     assert result.returncode != 0
-    # For 1.30.x, we expect this message.
     assert (
         'For `pants_version = "1.30.1"`, Pants requires Python 3.6, 3.7, or 3.8 to run.'
         in result.stderr


### PR DESCRIPTION
We now choose and validate the Python interpreter based on the Pants version.

* Pants 1.x and 2.0 will continue to prefer 3.6, then 3.7, then 3.8, as 3.6 is the best tested.
    * It would be better to prefer 3.8 because it means Pants will work on Py38 code with dep inference, but there are some known Pantsd issues with Py38.
* Pants 2.1 will prefer 3.7, then 3.8, then the deprecated 3.6.
* Pants 2.2+ will require 3.7 or 3.8.

We will likely add 3.9 support soon, but we're not sure which version. Rather than speculating, we will update this script when the time is right.