### PR TITLE
Revert "Update virtualenv supporting newer entry points (#92)"

### DIFF
--- a/pants
+++ b/pants
@@ -34,7 +34,7 @@ fi
 
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
-VENV_VERSION=${VENV_VERSION:-20.2.2}
+VENV_VERSION=${VENV_VERSION:-16.4.3}
 
 VENV_PACKAGE=virtualenv-${VENV_VERSION}
 VENV_TARBALL=${VENV_PACKAGE}.tar.gz
@@ -204,20 +204,7 @@ function bootstrap_venv {
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
     ) 1>&2
   fi
-
-  local venv_path="${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
-  local venv_entry_point
-
-  # shellcheck disable=SC2086
-  if [[ -f "${venv_path}/virtualenv.py" ]]; then
-    venv_entry_point="${venv_path}/virtualenv.py"
-  elif [[ -f "${venv_path}/src/virtualenv/__main__.py" ]]; then
-    venv_entry_point="${venv_path}/src/virtualenv/__main__.py"
-  else
-    die "Could not find virtualenv entry point for version $VENV_VERSION"
-  fi
-
-  echo "${venv_entry_point}"
+  echo "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
 }
 
 function find_links_url {
@@ -257,10 +244,12 @@ function bootstrap_pants {
 
   if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
     (
-      local venv_entry_point="$(bootstrap_venv)"
+      local venv_path
+      venv_path="$(bootstrap_venv)"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-      "${python}" "${venv_entry_point}" --no-download "${staging_dir}/install" && \
+      # shellcheck disable=SC2086
+      "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install" && \
       "${staging_dir}/install/bin/pip" install -U pip && \
       "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \


### PR DESCRIPTION
https://github.com/pantsbuild/setup/pull/92 introduced a regression in the `./pants` script. I have reproduced a reported failure to bootstrap a repo by trying to bootstrap the example-python repository on macOS 10.15.7 which results in the following error:

```
~/TC/example-python$ ./pants --version
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   122  100   122    0     0    606      0 --:--:-- --:--:-- --:--:--   610
100   281  100   281    0     0    747      0 --:--:-- --:--:-- --:--:--   747
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 8861k  100 8861k    0     0  7348k      0  0:00:01  0:00:01 --:--:-- 14.2M
Traceback (most recent call last):
  File "/Users/XXX/.cache/pants/setup/bootstrap-Darwin-x86_64/virtualenv-20.2.2/src/virtualenv/__main__.py", line 77, in <module>
    run_with_catch()  # pragma: no cov
  File "/Users/XXX/.cache/pants/setup/bootstrap-Darwin-x86_64/virtualenv-20.2.2/src/virtualenv/__main__.py", line 58, in run_with_catch
    from virtualenv.config.cli.parser import VirtualEnvOptions
ModuleNotFoundError: No module named 'virtualenv'
./pants: line 293: /Users/XXX/.cache/pants/setup/bootstrap-Darwin-x86_64/2.0.0rc1_py38/bin/python: No such file or directory
```

The regression was originally reported on Slack: https://pantsbuild.slack.com/archives/C046T6T9U/p1608991742321800


