### PR TITLE
Pants 2.5+ supports Python 3.9

### DIFF
--- a/pants
+++ b/pants
@@ -141,14 +141,14 @@ function set_supported_python_versions {
     supported_python_versions_int=('37' '38' '36')
     supported_message='3.7, 3.8, or 3.6 (deprecated)'
   elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -lt 5 ]]; then
-    supported_python_versions_decimal=('3.7' '3.8')
-    supported_python_versions_int=('37' '38')
+    supported_python_versions_decimal=('3.8' '3.7')
+    supported_python_versions_int=('38' '37')
     supported_message='3.7 or 3.8'
   else
     # We put 3.9 first because Apple Silicon only works properly with Python 3.9, even though it's possible to have
     # older Pythons installed. This makes it more likely that Pants will work out-of-the-box.
-    supported_python_versions_decimal=('3.9' '3.7' '3.8')
-    supported_python_versions_int=('39' '37' '38')
+    supported_python_versions_decimal=('3.9' '3.8' '3.7')
+    supported_python_versions_int=('39' '38' '37')
     supported_message='3.7, 3.8, or 3.9'
   fi
 }

--- a/pants
+++ b/pants
@@ -140,10 +140,16 @@ function set_supported_python_versions {
     supported_python_versions_decimal=('3.7' '3.8' '3.6')
     supported_python_versions_int=('37' '38' '36')
     supported_message='3.7, 3.8, or 3.6 (deprecated)'
-  else
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -lt 5 ]]; then
     supported_python_versions_decimal=('3.7' '3.8')
     supported_python_versions_int=('37' '38')
     supported_message='3.7 or 3.8'
+  else
+    # We put 3.9 first because Apple Silicon only works properly with Python 3.9, even though it's possible to have
+    # older Pythons installed. This makes it more likely that Pants will work out-of-the-box.
+    supported_python_versions_decimal=('3.9' '3.7' '3.8')
+    supported_python_versions_int=('39' '37' '38')
+    supported_message='3.7, 3.8, or 3.9'
   fi
 }
 

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -149,6 +149,6 @@ def test_pants_2(checker: SmokeTester) -> None:
 
 
 def test_pants_at_sha(checker: SmokeTester) -> None:
-    sha = "41ec94b758aac39c13f59e694fba5ed096a51ba9"
-    version = "2.0.0.dev6+git41ec94b7"
+    sha = "e4a00eb2750d00371cfe1d438c872ec3ea926369"
+    version = "2.3.0.dev6+gite4a00eb"
     checker.smoke_test(python_version=None, pants_version=version, sha=sha)

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -93,16 +93,17 @@ class SmokeTester:
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
         binary_command = ["./pants", "binary", "//:bin"]
+        binary_tgt_name = "python_binary" if pants_version.startswith("1") else "pex_binary"
         with self._maybe_run_pyenv_local(python_version):
             create_pants_config(parent_folder=self.build_root, pants_version=pants_version)
             (self.build_root / "BUILD").write_text(
                 textwrap.dedent(
-                    """
+                    f"""
                     target(name='test')
 
                     # To test that we can resolve these, esp. against custom shas.
                     pants_requirement(name='pantsreq')
-                    python_binary(name='bin', dependencies=[':pantsreq'], entry_point='dummy')
+                    {binary_tgt_name}(name='bin', dependencies=[':pantsreq'], entry_point='fake')
                     """
                 )
             )

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -98,6 +98,9 @@ class SmokeTester:
         else:
             goal = "package"
             tgt_type = "pex_binary"
+            # Force the pex_binary to use this interpreter constraint so that pantsbuild.pants is
+            # resolvable via the pants_requirement().
+            env["PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS"] = "['==3.7.*']"
         binary_command = ["./pants", goal, "//:bin"]
         with self._maybe_run_pyenv_local(python_version):
             create_pants_config(parent_folder=self.build_root, pants_version=pants_version)

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -6,6 +6,7 @@
 import os
 import shutil
 import subprocess
+import textwrap
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -91,19 +92,38 @@ class SmokeTester:
             env["PANTS_SHA"] = sha
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
+        if pants_version.startswith("1"):
+            goal = "binary"
+            tgt_type = "python_binary"
+        else:
+            goal = "package"
+            tgt_type = "pex_binary"
+        binary_command = ["./pants", goal, "//:bin"]
         with self._maybe_run_pyenv_local(python_version):
             create_pants_config(parent_folder=self.build_root, pants_version=pants_version)
-            (self.build_root / "BUILD").write_text("target(name='test')")
+            (self.build_root / "BUILD").write_text(
+                textwrap.dedent(
+                    f"""
+                    target(name='test')
+
+                    # To test that we can resolve these, esp. against custom shas.
+                    pants_requirement(name='pantsreq')
+                    {tgt_type}(name='bin', dependencies=[':pantsreq'], entry_point='fake')
+                    """
+                )
+            )
 
             def run_command(command: List[str], **kwargs: Any) -> None:
                 subprocess.run(command, check=True, cwd=str(self.build_root), **kwargs)
 
             run_command(version_command, env=env)
             run_command(list_command, env=env)
+            run_command(binary_command, env=env)
             if "SKIP_PANTSD_TESTS" not in os.environ:
                 env_with_pantsd = {**env, "PANTS_ENABLE_PANTSD": "True"}
                 run_command(version_command, env=env_with_pantsd)
                 run_command(list_command, env=env_with_pantsd)
+                run_command(binary_command, env=env_with_pantsd)
 
     def smoke_test_for_all_python_versions(self, *python_versions: str, pants_version: str) -> None:
         for python_version in python_versions:
@@ -126,6 +146,6 @@ def test_pants_2(checker: SmokeTester) -> None:
 
 
 def test_pants_at_sha(checker: SmokeTester) -> None:
-    sha = "e4a00eb2750d00371cfe1d438c872ec3ea926369"
-    version = "2.3.0.dev6+gite4a00eb"
+    sha = "41ec94b758aac39c13f59e694fba5ed096a51ba9"
+    version = "2.0.0.dev6+git41ec94b7"
     checker.smoke_test(python_version=None, pants_version=version, sha=sha)

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -92,8 +92,13 @@ class SmokeTester:
             env["PANTS_SHA"] = sha
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
-        binary_command = ["./pants", "binary", "//:bin"]
-        binary_tgt_name = "python_binary" if pants_version.startswith("1") else "pex_binary"
+        if pants_version.startswith("1"):
+            goal = "binary"
+            tgt_type = "python_binary"
+        else:
+            goal = "package"
+            tgt_type = "pex_binary"
+        binary_command = ["./pants", goal, "//:bin"]
         with self._maybe_run_pyenv_local(python_version):
             create_pants_config(parent_folder=self.build_root, pants_version=pants_version)
             (self.build_root / "BUILD").write_text(
@@ -103,7 +108,7 @@ class SmokeTester:
 
                     # To test that we can resolve these, esp. against custom shas.
                     pants_requirement(name='pantsreq')
-                    {binary_tgt_name}(name='bin', dependencies=[':pantsreq'], entry_point='fake')
+                    {tgt_type}(name='bin', dependencies=[':pantsreq'], entry_point='fake')
                     """
                 )
             )

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -129,14 +129,14 @@ def checker(pyenv_bin: str, pyenv_versions: List[str], build_root: Path) -> Smok
     return SmokeTester(pyenv_bin=pyenv_bin, pyenv_versions=pyenv_versions, build_root=build_root)
 
 
-def test_pants_1_28(checker: SmokeTester) -> None:
-    checker.smoke_test(python_version=None, pants_version="1.28.0")
-    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.28.0")
+def test_pants_1(checker: SmokeTester) -> None:
+    checker.smoke_test(python_version=None, pants_version="1.30.4")
+    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="1.30.4")
 
 
-def test_pants_2_0(checker: SmokeTester) -> None:
-    checker.smoke_test(python_version=None, pants_version="2.0.0b1")
-    checker.smoke_test_for_all_python_versions("3.6", "3.7", "3.8", pants_version="2.0.0b1")
+def test_pants_2(checker: SmokeTester) -> None:
+    checker.smoke_test(python_version=None, pants_version="2.3.0")
+    checker.smoke_test_for_all_python_versions("3.7", "3.8", pants_version="2.3.0")
 
 
 def test_pants_at_sha(checker: SmokeTester) -> None:


### PR DESCRIPTION
This also defaults to Python 3.8 over 3.7 for Pants 2.2+, given the performance improvements.

This stops testing that we can package `pants_requirement()` when using a SHA, as this is the wrong place to test that. That belongs in a test in pantsbuild/pants. It was non-trivial to get the test to still work across 1.30 and 2.x due to issues like renaming `python_binary` to `pex_binary`.