### PR TITLE
Use latest version of virtualenv

### DIFF
--- a/pants
+++ b/pants
@@ -40,6 +40,7 @@ PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 # See https://virtualenv.pypa.io/en/latest/installation.html#via-zipapp
 VIRTUALENV_ZIPAPP=virtualenv.pyz
 VIRTUALENV_ZIPAPP_URL="https://bootstrap.pypa.io/virtualenv/3.6/${VIRTUALENV_ZIPAPP}"
+VIRTUALENV_ZIPAPP_EXPECTED_SHA256="9d5c8b09cdeaf44414f07902d2ae45c4bb8a2085717d66f82ae389a9c6f94425"
 
 COLOR_RED="\x1b[31m"
 COLOR_GREEN="\x1b[32m"
@@ -110,9 +111,9 @@ function determine_pants_version {
 
   pants_version="$(get_pants_config_value 'pants_version')"
   if [[ -z "${pants_version}" ]]; then
-    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the
-\`[GLOBAL]\` scope. See https://pypi.org/project/pantsbuild.pants/#history for all released
-versions and https://www.pantsbuild.org/docs/installation for more instructions."
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
+See https://pypi.org/project/pantsbuild.pants/#history for all released versions
+and https://www.pantsbuild.org/docs/installation for more instructions."
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
@@ -186,7 +187,7 @@ function determine_python_exe {
     fi
   fi
   local python_exe
-  python_exe="$(get_exe_path_or_die "${python_bin_name}")"
+  python_exe="$(get_exe_path_or_die "${python_bin_name}")" || exit 1
   local major_minor_version
   major_minor_version="$(get_python_major_minor_version "${python_exe}")"
   for valid_version in "${supported_python_versions_int[@]}"; do
@@ -209,9 +210,14 @@ function bootstrap_virtualenv {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       cd "${staging_dir}"
       curl -LO "${VIRTUALENV_ZIPAPP_URL}"
+      fingerprint="$(shasum -a 256 "${VIRTUALENV_ZIPAPP}" | cut -d' ' -f1)"
+      if [[ "${VIRTUALENV_ZIPAPP_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
+        die "SHA256 of ${staging_dir}/${VIRTUALENV_ZIPAPP} is not as expected. Aborting."
+      fi
       ln -s "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${staging_dir}/latest"
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
-    ) 1>&2
+      green "SHA256 fingerprint of "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}" verified."
+    ) 1>&2 || exit 1
   fi
   echo "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
 }
@@ -265,7 +271,7 @@ function bootstrap_pants {
         # The venv module is not available, so download and use the virtualenv zipapp.
         green "${python} does not have the venv module avilable, using virtualenv instead."
         local virtualenv_path
-        virtualenv_path="$(bootstrap_virtualenv)"
+        virtualenv_path="$(bootstrap_virtualenv)" || exit 1
         virtualenv_cmd="${python} ${virtualenv_path} --no-download"
       fi
 
@@ -277,7 +283,7 @@ function bootstrap_pants {
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
       mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}" && \
       green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."
-    ) 1>&2
+    ) 1>&2 || exit 1
   fi
   echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
 }
@@ -286,7 +292,8 @@ function bootstrap_pants {
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 pants_version="$(determine_pants_version)"
 python="$(determine_python_exe "${pants_version}")"
-pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")" || exit 1
+
 pants_python="${pants_dir}/bin/python"
 pants_binary="${pants_dir}/bin/pants"
 pants_extra_args=""

--- a/pants
+++ b/pants
@@ -35,7 +35,8 @@ fi
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
 VIRTUALENV_ZIPAPP=virtualenv.pyz
-VIRTUALENV_ZIPAPP_URL="https://raw.githubusercontent.com/pypa/get-virtualenv/20.4.7/public/${VIRTUALENV_ZIPAPP}"
+VIRTUALENV_VERSION=20.4.7
+VIRTUALENV_ZIPAPP_URL="https://raw.githubusercontent.com/pypa/get-virtualenv/${VIRTUALENV_VERSION}/public/${VIRTUALENV_ZIPAPP}"
 VIRTUALENV_ZIPAPP_EXPECTED_SHA256="9d5c8b09cdeaf44414f07902d2ae45c4bb8a2085717d66f82ae389a9c6f94425"
 
 COLOR_RED="\x1b[31m"
@@ -214,8 +215,8 @@ EOF
 
 function bootstrap_virtualenv {
   local python="$1"
-  local bootstrapped="${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
-  if [[ ! -d "${bootstrapped}" ]]; then
+  local bootstrapped="${PANTS_BOOTSTRAP}/virtualenv-${VIRTUALENV_VERSION}/${VIRTUALENV_ZIPAPP}"
+  if [[ ! -f "${bootstrapped}" ]]; then
     (
       green "Downloading the virtualenv zipapp"
       mkdir -p "${PANTS_BOOTSTRAP}"
@@ -228,6 +229,7 @@ function bootstrap_virtualenv {
         die "SHA256 of ${VIRTUALENV_ZIPAPP_URL} is not as expected. Aborting."
       fi
       green "SHA256 fingerprint of ${VIRTUALENV_ZIPAPP_URL} verified."
+      mkdir -p "$(dirname "${bootstrapped}")"
       mv -f "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${bootstrapped}"
       rmdir "${staging_dir}"
     ) 1>&2 || exit 1

--- a/pants
+++ b/pants
@@ -213,8 +213,8 @@ EOF
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
 function bootstrap_virtualenv {
-  python="$1"
-  bootstrapped="${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
   if [[ ! -d "${bootstrapped}" ]]; then
     (
       green "Downloading the virtualenv zipapp"
@@ -267,38 +267,27 @@ function bootstrap_pants {
    fi
   local python_major_minor_version
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
-  local target_folder_name
-  target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local bootstrapped="${PANTS_BOOTSTRAP}/${target_folder_name}"
 
-  if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
+  if [[ ! -d "${bootstrapped}" ]]; then
     (
       green "Bootstrapping Pants using ${python}"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-
-      if "${python}" -c "import venv" > /dev/null  2>&1; then
-        # It is safer and faster to use venv, so we do so when possible.
-        green "${python} has the venv module available, using it."
-        virtualenv_cmd="${python} -m venv"
-      else
-        # The venv module is not available, so download and use the virtualenv zipapp.
-        green "${python} does not have the venv module available, using virtualenv instead."
-        local virtualenv_path
-        virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
-        virtualenv_cmd="${python} ${virtualenv_path} --no-download"
-      fi
-
-      green "Installing ${pants_requirement} into a virtual environment at ${PANTS_BOOTSTRAP}/${target_folder_name}"
+      local virtualenv_path
+      virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
+      green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
       # shellcheck disable=SC2086
-      eval "${virtualenv_cmd} ${staging_dir}/install" && \
+      ${python} "${virtualenv_path}" --no-download "${staging_dir}/install" && \
       "${staging_dir}/install/bin/pip" install -U pip && \
       "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
-      mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}" && \
-      green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."
+      mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \
+      green "New virtual environment successfully created at ${bootstrapped}."
     ) 1>&2 || exit 1
   fi
-  echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
+  echo "${bootstrapped}"
 }
 
 # Ensure we operate from the context of the ./pants buildroot.

--- a/pants
+++ b/pants
@@ -232,7 +232,7 @@ function bootstrap_virtualenv {
       fi
       ln -s "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${staging_dir}/latest"
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
-      green "SHA256 fingerprint of "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}" verified."
+      green "SHA256 fingerprint of ${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP} verified."
     ) 1>&2 || exit 1
   fi
   echo "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"

--- a/pants
+++ b/pants
@@ -228,8 +228,8 @@ function bootstrap_virtualenv {
         die "SHA256 of ${VIRTUALENV_ZIPAPP_URL} is not as expected. Aborting."
       fi
       green "SHA256 fingerprint of ${VIRTUALENV_ZIPAPP_URL} verified."
-      ln -s "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${staging_dir}/latest"
-      mv "${staging_dir}/latest" "${bootstrapped}"
+      mv -f "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${bootstrapped}"
+      rmdir "${staging_dir}"
     ) 1>&2 || exit 1
   fi
   echo "${bootstrapped}"

--- a/pants
+++ b/pants
@@ -34,12 +34,8 @@ fi
 
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
-# Note that this URL points to the zipapp for the latest version of virtualenv
-# that supports the Python version specified in the URL. So it can be set to
-# the lowest version of Python we support running Pants on.
-# See https://virtualenv.pypa.io/en/latest/installation.html#via-zipapp
 VIRTUALENV_ZIPAPP=virtualenv.pyz
-VIRTUALENV_ZIPAPP_URL="https://bootstrap.pypa.io/virtualenv/3.6/${VIRTUALENV_ZIPAPP}"
+VIRTUALENV_ZIPAPP_URL="https://raw.githubusercontent.com/pypa/get-virtualenv/20.4.7/public/${VIRTUALENV_ZIPAPP}"
 VIRTUALENV_ZIPAPP_EXPECTED_SHA256="9d5c8b09cdeaf44414f07902d2ae45c4bb8a2085717d66f82ae389a9c6f94425"
 
 COLOR_RED="\x1b[31m"
@@ -218,7 +214,8 @@ EOF
 
 function bootstrap_virtualenv {
   python="$1"
-  if [[ ! -d "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}" ]]; then
+  bootstrapped="${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
+  if [[ ! -d "${bootstrapped}" ]]; then
     (
       green "Downloading the virtualenv zipapp"
       mkdir -p "${PANTS_BOOTSTRAP}"
@@ -228,14 +225,14 @@ function bootstrap_virtualenv {
       curl -LO "${VIRTUALENV_ZIPAPP_URL}"
       fingerprint="$(compute_sha256 "${python}" "${VIRTUALENV_ZIPAPP}")"
       if [[ "${VIRTUALENV_ZIPAPP_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
-        die "SHA256 of ${staging_dir}/${VIRTUALENV_ZIPAPP} is not as expected. Aborting."
+        die "SHA256 of ${VIRTUALENV_ZIPAPP_URL} is not as expected. Aborting."
       fi
+      green "SHA256 fingerprint of ${VIRTUALENV_ZIPAPP_URL} verified."
       ln -s "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${staging_dir}/latest"
-      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
-      green "SHA256 fingerprint of ${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP} verified."
+      mv "${staging_dir}/latest" "${bootstrapped}"
     ) 1>&2 || exit 1
   fi
-  echo "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
+  echo "${bootstrapped}"
 }
 
 function find_links_url {

--- a/pants
+++ b/pants
@@ -34,6 +34,13 @@ fi
 
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
+# Note that this URL points to the zipapp for the latest version of virtualenv
+# that supports the Python version specified in the URL. So it can be set to
+# the lowest version of Python we support running Pants on.
+# See https://virtualenv.pypa.io/en/latest/installation.html#via-zipapp
+VIRTUALENV_ZIPAPP=virtualenv.pyz
+VIRTUALENV_ZIPAPP_URL="https://bootstrap.pypa.io/virtualenv/3.6/${VIRTUALENV_ZIPAPP}"
+
 COLOR_RED="\x1b[31m"
 COLOR_GREEN="\x1b[32m"
 COLOR_RESET="\x1b[0m"
@@ -193,6 +200,22 @@ function determine_python_exe {
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
+function bootstrap_virtualenv {
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}" ]]; then
+    (
+      green "Downloading the virtualenv zipapp"
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO "${VIRTUALENV_ZIPAPP_URL}"
+      ln -s "${staging_dir}/${VIRTUALENV_ZIPAPP}" "${staging_dir}/latest"
+      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}"
+}
+
 function find_links_url {
   local pants_version="$1"
   local pants_sha="$2"
@@ -230,10 +253,25 @@ function bootstrap_pants {
 
   if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
     (
+      green "Bootstrapping Pants using ${python}"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+
+      if ${python} -c "import venv" > /dev/null  2>&1; then
+        # It is safer and faster to use venv, so we do so when possible.
+        green "${python} has the venv module available, using it."
+        virtualenv_cmd="${python} -m venv"
+      else
+        # The venv module is not available, so download and use the virtualenv zipapp.
+        green "${python} does not have the venv module avilable, using virtualenv instead."
+        local virtualenv_path
+        virtualenv_path="$(bootstrap_virtualenv)"
+        virtualenv_cmd="${python} ${virtualenv_path} --no-download"
+      fi
+
+      green "Installing ${pants_requirement} into a virtual environment at ${PANTS_BOOTSTRAP}/${target_folder_name}"
       # shellcheck disable=SC2086
-      "${python}" -m venv "${staging_dir}/install" && \
+      eval "${virtualenv_cmd} ${staging_dir}/install" && \
       "${staging_dir}/install/bin/pip" install -U pip && \
       "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \

--- a/pants
+++ b/pants
@@ -263,13 +263,13 @@ function bootstrap_pants {
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
 
-      if ${python} -c "import venv" > /dev/null  2>&1; then
+      if "${python}" -c "import venv" > /dev/null  2>&1; then
         # It is safer and faster to use venv, so we do so when possible.
         green "${python} has the venv module available, using it."
         virtualenv_cmd="${python} -m venv"
       else
         # The venv module is not available, so download and use the virtualenv zipapp.
-        green "${python} does not have the venv module avilable, using virtualenv instead."
+        green "${python} does not have the venv module available, using virtualenv instead."
         local virtualenv_path
         virtualenv_path="$(bootstrap_virtualenv)" || exit 1
         virtualenv_cmd="${python} ${virtualenv_path} --no-download"

--- a/pants
+++ b/pants
@@ -34,11 +34,6 @@ fi
 
 PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
 
-VENV_VERSION=${VENV_VERSION:-16.4.3}
-
-VENV_PACKAGE=virtualenv-${VENV_VERSION}
-VENV_TARBALL=${VENV_PACKAGE}.tar.gz
-
 COLOR_RED="\x1b[31m"
 COLOR_GREEN="\x1b[32m"
 COLOR_RESET="\x1b[0m"
@@ -57,6 +52,7 @@ function green() {
 }
 
 function tempdir {
+  mkdir -p "$1"
   mktemp -d "$1"/pants.XXXXXX
 }
 
@@ -197,22 +193,6 @@ function determine_python_exe {
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
-function bootstrap_venv {
-  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]; then
-    (
-      mkdir -p "${PANTS_BOOTSTRAP}"
-      local staging_dir
-      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-      cd "${staging_dir}"
-      curl -LO "https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}"
-      tar -xzf "${VENV_TARBALL}"
-      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest"
-      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
-    ) 1>&2
-  fi
-  echo "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
-}
-
 function find_links_url {
   local pants_version="$1"
   local pants_sha="$2"
@@ -250,12 +230,10 @@ function bootstrap_pants {
 
   if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
     (
-      local venv_path
-      venv_path="$(bootstrap_venv)"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       # shellcheck disable=SC2086
-      "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install" && \
+      "${python}" -m venv "${staging_dir}/install" && \
       "${staging_dir}/install/bin/pip" install -U pip && \
       "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \

--- a/pants
+++ b/pants
@@ -198,10 +198,26 @@ function determine_python_exe {
   die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
 }
 
+function compute_sha256 {
+  local python="$1"
+  local path="$2"
+
+  "$python" <<EOF
+import hashlib
+
+hasher = hashlib.sha256()
+with open('${path}', 'rb') as fp:
+    buf = fp.read()
+    hasher.update(buf)
+print(hasher.hexdigest())
+EOF
+}
+
 # TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
 # functions.  Any tmp dir w/o a symlink pointing to it can go.
 
 function bootstrap_virtualenv {
+  python="$1"
   if [[ ! -d "${PANTS_BOOTSTRAP}/${VIRTUALENV_ZIPAPP}" ]]; then
     (
       green "Downloading the virtualenv zipapp"
@@ -210,7 +226,7 @@ function bootstrap_virtualenv {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       cd "${staging_dir}"
       curl -LO "${VIRTUALENV_ZIPAPP_URL}"
-      fingerprint="$(shasum -a 256 "${VIRTUALENV_ZIPAPP}" | cut -d' ' -f1)"
+      fingerprint="$(compute_sha256 "${python}" "${VIRTUALENV_ZIPAPP}")"
       if [[ "${VIRTUALENV_ZIPAPP_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
         die "SHA256 of ${staging_dir}/${VIRTUALENV_ZIPAPP} is not as expected. Aborting."
       fi
@@ -271,7 +287,7 @@ function bootstrap_pants {
         # The venv module is not available, so download and use the virtualenv zipapp.
         green "${python} does not have the venv module available, using virtualenv instead."
         local virtualenv_path
-        virtualenv_path="$(bootstrap_virtualenv)" || exit 1
+        virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
         virtualenv_cmd="${python} ${virtualenv_path} --no-download"
       fi
 

--- a/pants
+++ b/pants
@@ -279,7 +279,7 @@ function bootstrap_pants {
       virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
       green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
       # shellcheck disable=SC2086
-      ${python} "${virtualenv_path}" --no-download "${staging_dir}/install" && \
+      "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
       "${staging_dir}/install/bin/pip" install -U pip && \
       "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}" && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \


### PR DESCRIPTION
For compatibility with Python3.9.  We now consume virtualenv as a zipapp, as the previous method no longer works.

We also now check virtualenv's sha256, for added security. 
This change also fixes some cases where we weren't exiting an outer process when a subprocess exited on error. 