### PR TITLE
allow prepending args to Pants invocation

### DIFF
--- a/pants
+++ b/pants
@@ -279,5 +279,5 @@ if [[ -n "${PANTS_SHA:-}" ]]; then
 fi
 
 # shellcheck disable=SC2086
-exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+exec ${PANTS_PREPEND_ARGS:-} "${pants_python}" "${pants_binary}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"


### PR DESCRIPTION
Allow prepending arguments to a Pants invocation which is helpful for running Pants under a profiler.