### PR TITLE
update default branch name in pants script

### DIFF
--- a/pants
+++ b/pants
@@ -12,8 +12,8 @@
 
 set -eou pipefail
 
-# NOTE: To use an unreleased version of Pants from the pantsbuild/pants master branch,
-#  locate the master branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
+# NOTE: To use an unreleased version of Pants from the pantsbuild/pants main branch,
+#  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
 #
 # E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
 


### PR DESCRIPTION
the default branch on the pants repo is `main` not `master` 
Also I am assuming this is the script hat gets published to https://static.pantsbuild.org/setup/pants
if this is the case, this update is worth doing and re-publishing (I assume there is a manual step since the script in https://static.pantsbuild.org/setup/pants is not the same one in this repo... just very similar)