### PR TITLE
silence asdf warnings from ./pants for python 3.9

### DIFF
--- a/pants
+++ b/pants
@@ -191,12 +191,8 @@ function determine_default_python_exe {
     if [[ -z "${interpreter_path}" ]]; then
       continue
     fi
-    # Check if the Python version is installed via Pyenv but not activated.
-    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
-      continue
-    fi
-    # Check if a version is shimmed by asdf but not configured.
-    if ! ${interpreter_path} --version >/dev/null 2>&1; then
+    # Check if a version is shimmed by pyenv or asdf but not configured.
+    if ! "${interpreter_path}" --version >/dev/null 2>&1; then
       continue
     fi
     if [[ -n "$(check_python_exe_compatible_version "${interpreter_path}")" ]]; then

--- a/pants
+++ b/pants
@@ -195,6 +195,10 @@ function determine_default_python_exe {
     if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
       continue
     fi
+    # Check if a version is shimmed by asdf but not configured.
+    if ! ${interpreter_path} --version >/dev/null 2>&1; then
+      continue
+    fi
     if [[ -n "$(check_python_exe_compatible_version "${interpreter_path}")" ]]; then
       echo "${interpreter_path}" && return 0
     fi


### PR DESCRIPTION
If you are using [asdf](http://asdf-vm.com/) to manage python versions
and don't have 3.9 installed+configured, each run of pants will show an
error like:

```
No preset version installed for command python3.9
Please install a version by running one of the following:

asdf install python 3.6.15
asdf install python 3.8.12

or add one of the following versions in your config file at /Users/ryan.king/code/color/.tool-versions
python 3.9.1
python 3.9.7
```

The script will continue on, but I think this error would be confusing
for many people and this change should be safe.