### PR TITLE
Ensure venv setuptools works with Pants 1.30.x.

### DIFF
--- a/pants
+++ b/pants
@@ -343,7 +343,9 @@ function bootstrap_pants {
         scrub_PEX_env_vars
         # shellcheck disable=SC2086
         "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
-        "${staging_dir}/install/bin/pip" install -U pip && \
+        # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
+        # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
+        "${staging_dir}/install/bin/pip" install -U pip "setuptools<58" && \
         "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}"
       ) && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \


### PR DESCRIPTION
The 1.30.x series depends on pystache 0.5.4 which ships an sdist that
uses a setup.py legacy build with the use_2to3 keyword. Support for
that keyword was dropped in setuptools 58.

Fixes #111