### PR TITLE
Make pants bootstrap process produce less output and be less verbose

### DIFF
--- a/pants
+++ b/pants
@@ -256,6 +256,7 @@ function bootstrap_pex {
       cd "${staging_dir}"
       curl --proto "=https" \
            --tlsv1.2 \
+           --silent \
            --location \
            --remote-name \
            "${_PEX_URL}"
@@ -356,11 +357,11 @@ function bootstrap_pants {
       (
         scrub_PEX_env_vars
         # shellcheck disable=SC2086
-        "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
+        "${python}" "${virtualenv_path}" --quiet --no-download "${staging_dir}/install" && \
         # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
         # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
-        "${staging_dir}/install/bin/pip" install -U pip "setuptools<58" && \
-        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}"
+        "${staging_dir}/install/bin/pip" install --quiet -U pip "setuptools<58" && \
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off "${pants_requirement}"
       ) && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
       mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \

--- a/tests/test_first_time_install.py
+++ b/tests/test_first_time_install.py
@@ -23,7 +23,7 @@ def test_only_bootstraps_the_first_time(build_root: Path) -> None:
         encoding="utf-8",
         cwd=str(build_root),
     ).stderr
-    assert "Collecting pantsbuild.pants==" in first_run_pants_script_logging
+    assert "Bootstrapping Pants using" in first_run_pants_script_logging
     second_run_pants_script_logging = subprocess.run(
         ["./pants", "--version"],
         check=True,
@@ -31,7 +31,7 @@ def test_only_bootstraps_the_first_time(build_root: Path) -> None:
         encoding="utf-8",
         cwd=str(build_root),
     ).stderr
-    assert "Collecting pantsbuild.pants==" not in second_run_pants_script_logging
+    assert "Bootstrapping Pants using" not in second_run_pants_script_logging
 
 
 def test_relative_cache_locations_work(build_root: Path) -> None:
@@ -46,7 +46,7 @@ def test_relative_cache_locations_work(build_root: Path) -> None:
         env={**os.environ, "PANTS_SETUP_CACHE": "relative_dir"},
     )
     assert re.search(
-        r"virtual environment successfully created at .*/relative_dir/bootstrap.*/",
+        r"New virtual environment successfully created at .*/relative_dir/bootstrap.*/",
         result.stderr,
         flags=re.MULTILINE,
     )


### PR DESCRIPTION
I feel that the current output generated by the script is not very useful to most users (who just run pants in their repo, and not managing it)
so I think pants should have a cleaner and simpler UI and a clean bootstrap process is part of it.

@jsirois @stuhood @benjyw @Eric-Arellano 