### PR TITLE
Source PANTS_BOOTSTRAP script, defaults to .pants.bootstrap, if it exists.

### DIFF
--- a/pants
+++ b/pants
@@ -12,6 +12,12 @@
 
 set -eou pipefail
 
+# Source any custom bootstrap settings for Pants from PANTS_BOOTSTRAP if it exists.
+: ${PANTS_BOOTSTRAP:=".pants.bootstrap"}
+if [[ -f "${PANTS_BOOTSTRAP}" ]]; then
+  source "${PANTS_BOOTSTRAP}"
+fi
+
 # NOTE: To use an unreleased version of Pants from the pantsbuild/pants main branch,
 #  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
 #


### PR DESCRIPTION
This is a change we (at $-work) apply to all our `pants` scripts to setup defaults for running locally, values that are otherwise populated when running in CI/CD, as well as setting up some custom cert bundles etc.

It helps ensuring a proper environment to run pants in, without having to do any pre-steps to invoking `./pants`.
