### PR TITLE
Add 'bootstrap tools' (bootstrap-cache-key) via PANTS_BOOTSTRAP_TOOLS=1

### DIFF
--- a/pants
+++ b/pants
@@ -387,6 +387,50 @@ function bootstrap_pants {
   echo "${bootstrapped}"
 }
 
+function run_bootstrap_tools {
+  # functionality for introspecting the bootstrapping process, without actually doing it
+
+  case "${1:-}" in
+    bootstrap-cache-key)
+      local pants_version=$(determine_pants_version)
+      local python="$(determine_python_exe "${pants_version}")"
+
+      local requirements_file="$(mktemp)"
+      echo "${VIRTUALENV_REQUIREMENTS}" > "${requirements_file}"
+      local virtualenv_requirements_sha256="$(compute_sha256 "${python}" "${requirements_file}")"
+      rm "${requirements_file}"
+
+      local parts=(
+        "os_name=$(uname -s)"
+        "arch=$(uname -m)"
+        "python_path=${python}"
+        # the full interpreter information, for maximum compatibility
+        "python_version=$("$python" --version)"
+        "pex_version=${_PEX_VERSION}"
+        "virtualenv_requirements_sha256=${virtualenv_requirements_sha256}"
+        "pants_version=${pants_version}"
+      )
+      echo "${parts[*]}"
+      ;;
+    help|"")
+      cat <<EOF
+Usage: PANTS_BOOTSTRAP_TOOLS=1 $0 ...
+
+Subcommands:
+  bootstrap-cache-key
+    print an opaque that can be used as a key for accurate and safe caching of the pants bootstrap directories
+EOF
+      ;;
+    *)
+      die "Unknown subcommand for bootstrap tools (due to PANTS_BOOTSTRAP_TOOLS=1): $1 "
+  esac
+}
+
+if [[ "${PANTS_BOOTSTRAP_TOOLS:-}" = 1 ]]; then
+    run_bootstrap_tools "$@"
+    exit 0
+fi
+
 # Ensure we operate from the context of the ./pants buildroot.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 pants_version="$(determine_pants_version)"

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -204,6 +204,7 @@ class SmokeTester:
             env["PANTS_SHA"] = sha
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
+        bootstrap_cache_key_command = ["./pants", "bootstrap-cache-key"]
         if pants_version.startswith("1"):
             goal = "binary"
             tgt_type = "python_binary"
@@ -247,11 +248,13 @@ class SmokeTester:
             env = {**env, **python_setup.extra_env}
             run_command(version_command, env=env)
             run_command(list_command, env=env)
+            run_command(bootstrap_cache_key_command, env={**env, "PANTS_BOOTSTRAP_TOOLS": "1"})
             run_binary_command(env=env)
             if "SKIP_PANTSD_TESTS" not in env:
                 env_with_pantsd = {**env, "PANTS_ENABLE_PANTSD": "True"}
                 run_command(version_command, env=env_with_pantsd)
                 run_command(list_command, env=env_with_pantsd)
+                run_command(bootstrap_cache_key_command, env={**env, "PANTS_BOOTSTRAP_TOOLS": "1"})
                 run_binary_command(env=env_with_pantsd)
 
     def smoke_test_for_all_python_versions(


### PR DESCRIPTION
This adds functionality that can introspect the bootstrapping process, similar to `PEX_TOOLS=1 ./some.pex ...` being able to introspect a PEX file.

The motivating tool, added here, is `PANTS_BOOTSTRAP_TOOLS=1 ./pants bootstrap-cache-key` that prints a somewhat opaque string designed to be used as a key for CI caching systems. This is designed to help with https://github.com/pantsbuild/actions/issues/5, and is prompted by the discussion in https://github.com/pantsbuild/actions/pull/6#discussion_r978745702.

For example, on my system:

```
$ PANTS_BOOTSTRAP_TOOLS=1 ./pants bootstrap-cache-key
os_name=Darwin arch=arm64 python_path=/Users/huon/.pyenv/shims/python3.9 python_version=Python 3.9.10 pex_version=2.1.103 virtualenv_requirements_sha256=80b5a45ee3ee507e268799305d4e5e347c7e8346df6551b6a83df05396b3d941 pants_version=2.13.0
```

(This PR is a quick sketch, please lemme know if it doesn't make sense!)