### PR TITLE
Add version bootstrap tool subcommand, for capability checking

### DIFF
--- a/pants
+++ b/pants
@@ -68,6 +68,8 @@ COLOR_GREEN="\x1b[32m"
 COLOR_YELLOW="\x1b[33m"
 COLOR_RESET="\x1b[0m"
 
+INSTALL_URL="https://www.pantsbuild.org/docs/installation"
+
 function log() {
   echo -e "$@" 1>&2
 }
@@ -144,7 +146,7 @@ function determine_pants_version {
   if [[ -z "${pants_version}" ]]; then
     die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
 See https://pypi.org/project/pantsbuild.pants/#history for all released versions
-and https://www.pantsbuild.org/docs/installation for more instructions."
+and $INSTALL_URL for more instructions."
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
@@ -393,6 +395,10 @@ function bootstrap_pants {
 
 function run_bootstrap_tools {
   # functionality for introspecting the bootstrapping process, without actually doing it
+  if [[ "${PANTS_BOOTSTRAP_TOOLS}" -gt "$SCRIPT_VERSION" ]]; then
+      die "$0 script (bootstrap version $SCRIPT_VERSION) is too old for this invocation (with PANTS_BOOTSTRAP_TOOLS=${PANTS_BOOTSTRAP_TOOLS}).
+Please update it by following $INSTALL_URL"
+  fi
 
   case "${1:-}" in
     bootstrap-cache-key)
@@ -425,17 +431,29 @@ Usage: PANTS_BOOTSTRAP_TOOLS=1 $0 ...
 
 Subcommands:
   bootstrap-cache-key
-    print an opaque that can be used as a key for accurate and safe caching of the pants bootstrap directories
+    Print an opaque that can be used as a key for accurate and safe caching of
+    the pants bootstrap directories.
+
+    (Added in bootstrap version 1.)
+
   bootstrap-version
-    print a version number for the bootstrap script itself
+    Print a version number for the bootstrap script itself.
+
+    Distributed scripts (such as reusable CI formulae) that use these bootstrap
+    tools should set PANTS_BOOTSTRAP_TOOLS to the minimum script version for the
+    features they require. For example, if 'some-tool' was added in version 123:
+
+        PANTS_BOOTSTRAP_TOOLS=123 ./pants some-tool
+
+    (Added in bootstrap version 1.)
 EOF
       ;;
     *)
-      die "Unknown subcommand for bootstrap tools: $1. Do you mean to run without PANTS_BOOTSTRAP_TOOLS=1? Or, update this script (https://www.pantsbuild.org/docs/installation)?"
+      die "Unknown subcommand for bootstrap tools: $1. Do you mean to run without PANTS_BOOTSTRAP_TOOLS=1? Or, update this script ($INSTALL_URL)?"
   esac
 }
 
-if [[ "${PANTS_BOOTSTRAP_TOOLS:-}" = 1 ]]; then
+if [[ "${PANTS_BOOTSTRAP_TOOLS:-}" -gt 0 ]]; then
     run_bootstrap_tools "$@"
     exit 0
 fi

--- a/pants
+++ b/pants
@@ -416,7 +416,7 @@ function run_bootstrap_tools {
       )
       echo "${parts[*]}"
       ;;
-    version)
+    bootstrap-version)
       echo "$SCRIPT_VERSION"
       ;;
     help|"")
@@ -426,7 +426,7 @@ Usage: PANTS_BOOTSTRAP_TOOLS=1 $0 ...
 Subcommands:
   bootstrap-cache-key
     print an opaque that can be used as a key for accurate and safe caching of the pants bootstrap directories
-  version
+  bootstrap-version
     print a version number for the bootstrap script itself
 EOF
       ;;

--- a/pants
+++ b/pants
@@ -12,6 +12,10 @@
 
 set -eou pipefail
 
+# an arbitrary number: bump when there's a change that someone might want to query for
+# (e.g. checking $(PANTS_BOOTSTRAP_TOOLS=1 ./pants version) >= ...)
+SCRIPT_VERSION=1
+
 # Source any custom bootstrap settings for Pants from PANTS_BOOTSTRAP if it exists.
 : ${PANTS_BOOTSTRAP:=".pants.bootstrap"}
 if [[ -f "${PANTS_BOOTSTRAP}" ]]; then
@@ -412,6 +416,9 @@ function run_bootstrap_tools {
       )
       echo "${parts[*]}"
       ;;
+    version)
+      echo "$SCRIPT_VERSION"
+      ;;
     help|"")
       cat <<EOF
 Usage: PANTS_BOOTSTRAP_TOOLS=1 $0 ...
@@ -419,10 +426,12 @@ Usage: PANTS_BOOTSTRAP_TOOLS=1 $0 ...
 Subcommands:
   bootstrap-cache-key
     print an opaque that can be used as a key for accurate and safe caching of the pants bootstrap directories
+  version
+    print a version number for the bootstrap script itself
 EOF
       ;;
     *)
-      die "Unknown subcommand for bootstrap tools (due to PANTS_BOOTSTRAP_TOOLS=1): $1 "
+      die "Unknown subcommand for bootstrap tools: $1. Do you mean to run without PANTS_BOOTSTRAP_TOOLS=1? Or, update this script (https://www.pantsbuild.org/docs/installation)?"
   esac
 }
 

--- a/pants
+++ b/pants
@@ -146,7 +146,7 @@ function determine_pants_version {
   if [[ -z "${pants_version}" ]]; then
     die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
 See https://pypi.org/project/pantsbuild.pants/#history for all released versions
-and $INSTALL_URL for more instructions."
+and ${INSTALL_URL} for more instructions."
   fi
   pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
   pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
@@ -395,9 +395,9 @@ function bootstrap_pants {
 
 function run_bootstrap_tools {
   # functionality for introspecting the bootstrapping process, without actually doing it
-  if [[ "${PANTS_BOOTSTRAP_TOOLS}" -gt "$SCRIPT_VERSION" ]]; then
-      die "$0 script (bootstrap version $SCRIPT_VERSION) is too old for this invocation (with PANTS_BOOTSTRAP_TOOLS=${PANTS_BOOTSTRAP_TOOLS}).
-Please update it by following $INSTALL_URL"
+  if [[ "${PANTS_BOOTSTRAP_TOOLS}" -gt "${SCRIPT_VERSION}" ]]; then
+      die "$0 script (bootstrap version ${SCRIPT_VERSION}) is too old for this invocation (with PANTS_BOOTSTRAP_TOOLS=${PANTS_BOOTSTRAP_TOOLS}).
+Please update it by following ${INSTALL_URL}"
   fi
 
   case "${1:-}" in
@@ -423,7 +423,7 @@ Please update it by following $INSTALL_URL"
       echo "${parts[*]}"
       ;;
     bootstrap-version)
-      echo "$SCRIPT_VERSION"
+      echo "${SCRIPT_VERSION}"
       ;;
     help|"")
       cat <<EOF

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -300,3 +300,18 @@ def test_python_alias(checker: SmokeTester) -> None:
         alias="python",
         bad_aliases={"python3.7": "35", "python3": "27"},
     )
+
+
+def test_bootstrap_tools_version_checking(checker: SmokeTester) -> None:
+    result = subprocess.run(
+        ["./pants", "bootstrap-version"],
+        check=False,
+        cwd=str(checker.build_root),
+        env={**os.environ, "PANTS_BOOTSTRAP_TOOLS": "987654321"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+    assert result.stdout == ""
+    assert "is too old for this invocation (with PANTS_BOOTSTRAP_TOOLS=987654321)" in result.stderr


### PR DESCRIPTION
This expands on #128 to add another bootstrap tool subcommand: `bootstrap-version`. This is designed to just be a simple number that's bumped whenever there's a feature scripts might need to query for. The version number is also automatically checked against the (numeric) value of the `PANTS_BOOTSTRAP_TOOLS` key.

For instance, suppose the bootstrap tools already existed (at version 1), and then `bootstrap-cache-key` command was added, the version number would be bumped to 2, and then a consumer (such as https://github.com/pantsbuild/actions/pull/6) could run something like:

```shell
PANTS_BOOTSTRAP_CACHE_KEY=$(PANTS_BOOTSTRAP_TOOLS=2 ./pants bootstrap-cache-key)
```

Notes:

- I don't personally have concrete uses cases for this, but potentially adding different output like https://github.com/pantsbuild/setup/pull/128#pullrequestreview-1131761160 might use it.
- The subcommand name is `bootstrap-version` rather than `version` to avoid conflict with the subcommand on real-`pants` (i.e. `./pants version` without `PANTS_BOOTSTRAP_TOOLS=1` works, and prints the underlying pants version like 2.13.0, whereas `./pants bootstrap-version` errors out with `Unknown goal: bootstrap-version`)
- It's unfortunate I didn't add this in #128, because there may be people who installed the script supporting `PANTS_BOOTSTRAP_TOOLS` but not supporting this versioning. Maybe the window is small enough that that doesn't matter?
