### PR TITLE
Include actual python path (sys.executable) in bootstrap cache key

### DIFF
--- a/pants
+++ b/pants
@@ -394,6 +394,9 @@ function run_bootstrap_tools {
     bootstrap-cache-key)
       local pants_version=$(determine_pants_version)
       local python="$(determine_python_exe "${pants_version}")"
+      # the python above may be a shim (e.g. pyenv or homebrew), so let's get the actual path, as
+      # will be symlinked in the virtualenv
+      local python_executable_path="$("${python}" -c 'import sys; print(sys.executable)')"
 
       local requirements_file="$(mktemp)"
       echo "${VIRTUALENV_REQUIREMENTS}" > "${requirements_file}"
@@ -404,6 +407,7 @@ function run_bootstrap_tools {
         "os_name=$(uname -s)"
         "arch=$(uname -m)"
         "python_path=${python}"
+        "python_executable_path=${python_executable_path}"
         # the full interpreter information, for maximum compatibility
         "python_version=$("$python" --version)"
         "pex_version=${_PEX_VERSION}"

--- a/pants
+++ b/pants
@@ -394,9 +394,10 @@ function run_bootstrap_tools {
     bootstrap-cache-key)
       local pants_version=$(determine_pants_version)
       local python="$(determine_python_exe "${pants_version}")"
-      # the python above may be a shim (e.g. pyenv or homebrew), so let's get the actual path, as
-      # will be symlinked in the virtualenv
-      local python_executable_path="$("${python}" -c 'import sys; print(sys.executable)')"
+      # the python above may be a shim (e.g. pyenv or homebrew), so let's get an estimate of the
+      # actual path, as will be symlinked in the virtualenv. (NB. virtualenv does more complicated
+      # things, but we at least emulate the symlink-resolution that it does.)
+      local python_executable_path="$("${python}" -c 'import os, sys; print(os.path.realpath(sys.executable))')"
 
       local requirements_file="$(mktemp)"
       echo "${VIRTUALENV_REQUIREMENTS}" > "${requirements_file}"


### PR DESCRIPTION
This fixes a (small) bug in #128: the virtualenv may have a symlink to the 'actual' path of the python executable, and the `python_path` value used may've itself been a symlink or a shim. This uses `sys.executable` as an estimate of this path, which will hopefully be good enough for the circumstances where `bootstrap-cache-key` is useful.

After this patch, running on my system shows (note the difference between `python_path` and `python_executable_path`):

```
os_name=Darwin arch=arm64 python_path=/opt/homebrew/bin/python3.9 python_executable_path=/opt/homebrew/opt/python@3.9/bin/python3.9 python_version=Python 3.9.14 pex_version=2.1.103 virtualenv_requirements_sha256=80b5a45ee3ee507e268799305d4e5e347c7e8346df6551b6a83df05396b3d941 pants_version=2.13.0
```

It looks like `virtualenv` does more complicated things looking at `sys._base_executable` (if it exists). 

- https://github.com/pypa/virtualenv/blob/445a68dffa7ba5c0af3b02ec0545b760cd8c04ba/src/virtualenv/discovery/py_info.py#L66-L68
- https://github.com/pypa/virtualenv/blob/445a68dffa7ba5c0af3b02ec0545b760cd8c04ba/src/virtualenv/discovery/py_info.py#L132-L145
- https://github.com/pypa/virtualenv/blob/445a68dffa7ba5c0af3b02ec0545b760cd8c04ba/src/virtualenv/create/via_global_ref/venv.py#L19

I don't think it's worth reproducing that logic, and it's not possible to invoke virtualenv directly at this point (this needs to be able to run before installing any packages). An alternative would be to no longer use `virtualenv` and instead switch to the stdlib `venv`, which _can_ be run as part of the cache-key process. I suspect the use of `virtualenv` may've been from before pants required Python version >= 3.3 (when venv was added)? Or maybe pants uses features beyond what `python -m venv ...` can offer?