### PR TITLE
Don't `cd` into temp dirs when boostrapping Pants.

### DIFF
--- a/pants
+++ b/pants
@@ -265,14 +265,13 @@ function bootstrap_pex {
       mkdir -p "${PANTS_BOOTSTRAP}"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-      cd "${staging_dir}"
       curl --proto "=https" \
            --tlsv1.2 \
            --silent \
            --location \
-           --remote-name \
+           -o "${staging_dir}/pex" \
            "${_PEX_URL}"
-      fingerprint="$(compute_sha256 "${python}" "pex")"
+      fingerprint="$(compute_sha256 "${python}" "${staging_dir}/pex")"
       if [[ "${_PEX_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
         die "SHA256 of ${_PEX_URL} is not as expected. Aborting."
       fi
@@ -314,11 +313,10 @@ function bootstrap_virtualenv {
       mkdir -p "${PANTS_BOOTSTRAP}"
       local staging_dir
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
-      cd "${staging_dir}"
-      echo "${VIRTUALENV_REQUIREMENTS}" > requirements.txt
+      echo "${VIRTUALENV_REQUIREMENTS}" > "${staging_dir}/requirements.txt"
       (
         scrub_env_vars
-        "${python}" "${pex_path}" -r requirements.txt -c virtualenv -o virtualenv.pex
+        "${python}" "${pex_path}" -r "${staging_dir}/requirements.txt" -c virtualenv -o "${staging_dir}/virtualenv.pex"
       )
       mkdir -p "$(dirname "${bootstrapped}")"
       mv -f "${staging_dir}/virtualenv.pex" "${bootstrapped}"


### PR DESCRIPTION
Closes #132 

Changing the work dir prevents tools like `asdf` from seeing config files in the project root, resulting in confusing errors / use of unexpected Python versions.