### PR TITLE
add support for overriding pants_version on the command line

### DIFF
--- a/pants
+++ b/pants
@@ -26,6 +26,10 @@ fi
 #  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
 #
 # E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+#
+# You can also use PANTS_VERSION=<VERSION> to override the config version that is in the pants.toml file.
+#
+# E.g., PANTS_VERSION=2.13.0 ./pants --version
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 
@@ -139,6 +143,11 @@ function determine_pants_version {
   if [ -n "${PANTS_SHA:-}" ]; then
     # get_version_for_sha will echo the version, thus "returning" it from this function.
     get_version_for_sha "$PANTS_SHA"
+    return
+  fi
+
+  if [ -n "${PANTS_VERSION:-}" ]; then
+	echo "${PANTS_VERSION}"
     return
   fi
 

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -299,7 +299,7 @@ def test_pants_at_sha(checker: SmokeTester) -> None:
 
 def test_pants_at_version(checker: SmokeTester) -> None:
     version = "2.3.0.dev6+gite4a00eb"
-    override_version = "2.13.0"
+    override_version = "2.4.0"
     checker.smoke_test(
         python_version=None, pants_version=version, override_version=override_version
     )

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -198,10 +198,15 @@ class SmokeTester:
         alias: Optional[str] = None,
         bad_aliases: Optional[Mapping[str, str]] = None,
         sha: Optional[str] = None,
+        override_version: Optional[str] = None,
     ) -> None:
         env = {**os.environ}
         if sha:
             env["PANTS_SHA"] = sha
+
+        if override_version:
+            env["PANTS_VERSION"] = override_version
+
         version_command = ["./pants", "--version"]
         list_command = ["./pants", "list", "::"]
         bootstrap_cache_key_command = ["./pants", "bootstrap-cache-key"]
@@ -290,6 +295,14 @@ def test_pants_at_sha(checker: SmokeTester) -> None:
     sha = "e4a00eb2750d00371cfe1d438c872ec3ea926369"
     version = "2.3.0.dev6+gite4a00eb"
     checker.smoke_test(python_version=None, pants_version=version, sha=sha)
+
+
+def test_pants_at_version(checker: SmokeTester) -> None:
+    version = "2.3.0.dev6+gite4a00eb"
+    override_version = "2.13.0"
+    checker.smoke_test(
+        python_version=None, pants_version=version, override_version=override_version
+    )
 
 
 def test_python_alias(checker: SmokeTester) -> None:


### PR DESCRIPTION
This would help support running different pants version easily on CI and while testing various versions, as opposed to editing the pants.toml file. Tested it locally on my plugin repos and it seems to work. Unfortunately I can't run the tests as I don't have a Python 3.7 on hand. They also don't seem to validate what is actually ran, but I added a case at least.

In my OCI backend repo I get this:

```console
$ PANTS_VERSION=2.14.0 pants --version
2.14.0

$ PANTS_VERSION=2.15.0a1 pants --version
20:51:45.74 [WARN] DEPRECATED: using `SubsystemRule(SkopeoTool)` is scheduled to be removed in version 2.17.0dev0.

Use `*SkopeoTool.rules()` instead.
20:51:45.74 [WARN] DEPRECATED: using `SubsystemRule(RuncTool)` is scheduled to be removed in version 2.17.0dev0.

Use `*RuncTool.rules()` instead.
20:51:45.74 [WARN] DEPRECATED: using `SubsystemRule(UmociTool)` is scheduled to be removed in version 2.17.0dev0.

Use `*UmociTool.rules()` instead.
2.15.0a1

$ pants --version
<snip warnings as above>
2.15.0a0
```

So all three report the expected version, and given the warnings for 2.15 alphas but not 2.14 it does switch the code too.