### PR TITLE
Add PANTS_DEBUG-ability

### DIFF
--- a/pants
+++ b/pants
@@ -400,7 +400,7 @@ function bootstrap_pants {
         # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
         # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
         "${staging_dir}/install/bin/pip" install --quiet -U pip "setuptools<58" && \
-        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off "${pants_requirement}"
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off ${pants_requirement}
       ) && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
       mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \

--- a/pants
+++ b/pants
@@ -493,6 +493,7 @@ if [[ -n "${PANTS_SHA:-}" ]]; then
   pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
 fi
 
+pants_debug_args=()
 if [ -n "${PANTS_DEBUG:-}" ]; then
   if [[ "$*" != *"--no-pantsd"* ]]; then
     echo "Error! Must pass '--no-pantsd' when using PANTS_DEBUG"
@@ -500,10 +501,10 @@ if [ -n "${PANTS_DEBUG:-}" ]; then
   fi
   # NB: We can't invoke `-m debugpy` as that'll prepend CWD to sys.path which might have unintended side-effects.
   # `-c` also prepends, but we strip that ourselves.
-  DEBUG_ARGS=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
+  pants_debug_args=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
   echo "Will launch debugpy server at '127.0.0.1:5678' waiting for client connection."
 fi
 
 # shellcheck disable=SC2086
-exec "${pants_python}" ${DEBUG_ARGS[@]} "${pants_binary}" ${pants_extra_args} \
+exec "${pants_python}" ${pants_debug_args[@]} "${pants_binary}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants
+++ b/pants
@@ -506,5 +506,5 @@ if [ -n "${PANTS_DEBUG:-}" ]; then
 fi
 
 # shellcheck disable=SC2086
-exec "${pants_python}" "${pants_debug_args[@]}" "${pants_binary}" ${pants_extra_args} \
+exec "${pants_python}" "${pants_debug_args[@]-}" "${pants_binary}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants
+++ b/pants
@@ -501,7 +501,7 @@ if [ -n "${PANTS_DEBUG:-}" ]; then
   fi
   # NB: We can't invoke `-m debugpy` as that'll prepend CWD to sys.path which might have unintended side-effects.
   # `-c` also prepends, but we strip that ourselves.
-  pants_binary=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
+  pants_binary=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client "${pants_binary[@]}")
   echo "Will launch debugpy server at '127.0.0.1:5678' waiting for client connection."
 fi
 

--- a/pants
+++ b/pants
@@ -382,7 +382,7 @@ function bootstrap_pants {
 
   local python_major_minor_version
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
-  local target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local target_folder_name="${pants_version}_py${python_major_minor_version}${debug_suffix}"
   local bootstrapped="${PANTS_BOOTSTRAP}/${target_folder_name}"
 
   if [[ ! -d "${bootstrapped}" ]]; then

--- a/pants
+++ b/pants
@@ -487,7 +487,7 @@ python="$(determine_python_exe "${pants_version}")"
 pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}" "${PANTS_DEBUG:-}")" || exit 1
 
 pants_python="${pants_dir}/bin/python"
-pants_binary="${pants_dir}/bin/pants"
+pants_binary=(${pants_dir}/bin/pants)
 pants_extra_args=""
 if [[ -n "${PANTS_SHA:-}" ]]; then
   pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
@@ -501,10 +501,10 @@ if [ -n "${PANTS_DEBUG:-}" ]; then
   fi
   # NB: We can't invoke `-m debugpy` as that'll prepend CWD to sys.path which might have unintended side-effects.
   # `-c` also prepends, but we strip that ourselves.
-  pants_debug_args=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
+  pants_binary=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
   echo "Will launch debugpy server at '127.0.0.1:5678' waiting for client connection."
 fi
 
 # shellcheck disable=SC2086
-exec "${pants_python}" "${pants_debug_args[@]-}" "${pants_binary}" ${pants_extra_args} \
+exec "${pants_python}" "${pants_binary[@]}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants
+++ b/pants
@@ -12,6 +12,8 @@
 
 set -eou pipefail
 
+echo "$SHELL --version"
+
 # an arbitrary number: bump when there's a change that someone might want to query for
 # (e.g. checking $(PANTS_BOOTSTRAP_TOOLS=1 ./pants version) >= ...)
 SCRIPT_VERSION=1

--- a/pants
+++ b/pants
@@ -362,6 +362,7 @@ function bootstrap_pants {
   local pants_version="$1"
   local python="$2"
   local pants_sha="${3:-}"
+  local pants_debug="${4:-}"
 
   local pants_requirement="pantsbuild.pants==${pants_version}"
   local maybe_find_links
@@ -369,7 +370,16 @@ function bootstrap_pants {
     maybe_find_links=""
   else
     maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
-   fi
+  fi
+
+  local debug_suffix
+  if [[ -z "${pants_debug}" ]]; then
+    debug_suffix=""
+  else
+    debug_suffix="-debug"
+    pants_requirement="${pants_requirement} debugpy==1.6.0"
+  fi
+
   local python_major_minor_version
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
   local target_folder_name="${pants_version}_py${python_major_minor_version}"
@@ -474,7 +484,7 @@ fi
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 pants_version="$(determine_pants_version)"
 python="$(determine_python_exe "${pants_version}")"
-pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")" || exit 1
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}" "${PANTS_DEBUG:-}")" || exit 1
 
 pants_python="${pants_dir}/bin/python"
 pants_binary="${pants_dir}/bin/pants"
@@ -483,6 +493,17 @@ if [[ -n "${PANTS_SHA:-}" ]]; then
   pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
 fi
 
+if [ -n "${PANTS_DEBUG:-}" ]; then
+  if [[ "$*" != *"--no-pantsd"* ]]; then
+    echo "Error! Must pass '--no-pantsd' when using PANTS_DEBUG"
+    exit 1
+  fi
+  # NB: We can't invoke `-m debugpy` as that'll prepend CWD to sys.path which might have unintended side-effects.
+  # `-c` also prepends, but we strip that ourselves.
+  DEBUG_ARGS=(-c "__import__(\"sys\").path.pop(0);__import__(\"debugpy.server.cli\").server.cli.main()" --listen 127.0.0.1:5678 --wait-for-client)
+  echo "Will launch debugpy server at '127.0.0.1:5678' waiting for client connection."
+fi
+
 # shellcheck disable=SC2086
-exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+exec "${pants_python}" ${DEBUG_ARGS[@]} "${pants_binary}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants
+++ b/pants
@@ -364,7 +364,7 @@ function bootstrap_pants {
   local pants_sha="${3:-}"
   local pants_debug="${4:-}"
 
-  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local pants_requirements=(pantsbuild.pants==${pants_version})
   local maybe_find_links
   if [[ -z "${pants_sha}" ]]; then
     maybe_find_links=""
@@ -377,7 +377,7 @@ function bootstrap_pants {
     debug_suffix=""
   else
     debug_suffix="-debug"
-    pants_requirement="${pants_requirement} debugpy==1.6.0"
+    pants_requirements+=(debugpy==1.6.0)
   fi
 
   local python_major_minor_version
@@ -392,7 +392,7 @@ function bootstrap_pants {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
       local virtualenv_path
       virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
-      green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
+      green "Installing ${pants_requirements[@]} into a virtual environment at ${bootstrapped}"
       (
         scrub_env_vars
         # shellcheck disable=SC2086
@@ -400,7 +400,7 @@ function bootstrap_pants {
         # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
         # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
         "${staging_dir}/install/bin/pip" install --quiet -U pip "setuptools<58" && \
-        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off ${pants_requirement}
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off "${pants_requirements[@]}"
       ) && \
       ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
       mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \

--- a/pants
+++ b/pants
@@ -12,8 +12,6 @@
 
 set -eou pipefail
 
-echo "$SHELL --version"
-
 # an arbitrary number: bump when there's a change that someone might want to query for
 # (e.g. checking $(PANTS_BOOTSTRAP_TOOLS=1 ./pants version) >= ...)
 SCRIPT_VERSION=1

--- a/pants
+++ b/pants
@@ -506,5 +506,5 @@ if [ -n "${PANTS_DEBUG:-}" ]; then
 fi
 
 # shellcheck disable=SC2086
-exec "${pants_python}" ${pants_debug_args[@]} "${pants_binary}" ${pants_extra_args} \
+exec "${pants_python}" "${pants_debug_args[@]}" "${pants_binary}" ${pants_extra_args} \
   --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     pytest
     typing_extensions
 commands =
+    $SHELL --version
     pytest -v {posargs}
 passenv =
     SKIP_PANTSD_TESTS

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     pytest
     typing_extensions
 commands =
-    $SHELL --version
     pytest -v {posargs}
 passenv =
     SKIP_PANTSD_TESTS


### PR DESCRIPTION
Adds the ability to debug Pants itself through DAP leveraging `debugpy`.

Now you can use `PANTS_DEBUG=1 ./pants --no-pantsd ...` and attach VS Code to the server and debug rule code.