### PR TITLE
A pantsup.sh script to easily install the latest scie-pants.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Shellcheck
+        run: shellcheck pantsup.sh
       - name: Run Checks
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@v2
         with:
           tox-env: format-check,lint,typecheck
   unit-tests:
@@ -34,18 +36,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, macos-11]
+        os: [ubuntu-20.04, macos-11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@v2
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@v2
         with:
           # We need to force pytest to use a terse base for its temp dirs or we hit errors like:
           # 2020-02-23T16:14:47,808: [0x1139575c0] /private/var/folders/17/5mc7816d3mndxjqgplq6057w0000gn/T/pytest-of-travis/pytest-0/test_pants_1_260/project_dir/.pids/watchman/watchman.sock: path is too long

--- a/pantsup.sh
+++ b/pantsup.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+set -euo pipefail
+
+function log() {
+  echo -e "$@" >&2
+}
+
+function warn() {
+  log "WARNING: " "$@"
+}
+
+function die() {
+  log "$@"
+  exit 1
+}
+
+function check_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null || die "This script requires the ${cmd} binary to be on the PATH."
+}
+
+_GC=()
+
+function gc() {
+  if (($# > 0)); then
+    check_cmd rm
+    _GC+=("$@")
+  else
+    rm -rf "${_GC[@]}"
+  fi
+}
+
+trap gc EXIT
+
+check_cmd uname
+
+function calculate_os() {
+  local os
+
+  os="$(uname -s)"
+  if [[ "${os}" =~ [Ll]inux ]]; then
+    echo linux
+  elif [[ "${os}" =~ [Dd]arwin ]]; then
+    echo macos
+  elif [[ "${os}" =~ [Ww]in|[Mm][Ii][Nn][Gg] ]]; then
+    # Powershell reports something like: Windows_NT
+    # Git bash reports something like: MINGW64_NT-10.0-22621
+    echo windows
+  else
+    die "Pants is not supported on this operating system (${os})."
+  fi
+}
+
+OS="$(calculate_os)"
+
+check_cmd basename
+if [[ "${OS}" == "windows" ]]; then
+  check_cmd pwsh
+else
+  check_cmd curl
+fi
+
+function fetch() {
+  local url="$1"
+  local dest_dir="$2"
+
+  local dest
+  dest="${dest_dir}/$(basename "${url}")"
+
+  if [[ "${OS}" == "windows" ]]; then
+    pwsh -c "Invoke-WebRequest -OutFile $dest -Uri $url"
+  else
+    curl --proto '=https' --tlsv1.2 -sSfL -o "${dest}" "${url}"
+  fi
+}
+
+if [[ "${OS}" == "macos" ]]; then
+  check_cmd shasum
+else
+  check_cmd sha256sum
+fi
+
+function sha256() {
+  if [[ "${OS}" == "macos" ]]; then
+    shasum --algorithm 256 "$@"
+  else
+    sha256sum "$@"
+  fi
+}
+
+check_cmd mktemp
+
+function install_from_url() {
+  local url="$1"
+  local dest="$2"
+
+  local workdir
+  workdir="$(mktemp -d)"
+  gc workdir
+
+  fetch "${url}.sha256" "${workdir}"
+  fetch "${url}" "${workdir}"
+  (
+    cd "${workdir}"
+    sha256 -c --status ./*.sha256 ||
+      die "Download from ${url} did not match the fingerprint at ${url}.sha256"
+  )
+  rm "${workdir}/"*.sha256
+  if [[ "${OS}" == "macos" ]]; then
+    mkdir -p "$(dirname "${dest}")"
+    install -m 755 "${workdir}/"* "${dest}"
+  else
+    install -D -m 755 "${workdir}/"* "${dest}"
+  fi
+}
+
+function calculate_arch() {
+  local arch
+
+  arch="$(uname -m)"
+  if [[ "${arch}" =~ x86[_-]64 ]]; then
+    echo x86_64
+  elif [[ "${arch}" =~ arm64|aarch64 ]]; then
+    echo aarch64
+  else
+    die "Pants is not supported for this chip architecture (${arch})."
+  fi
+}
+
+check_cmd cat
+
+function usage() {
+  cat <<EOF
+Usage: $0
+
+Installs pants.
+
+This actually installs the scie-pants binary, but names it "pants". You
+only need to run this once on a machine when you do not have "pants"
+available to run yet.
+
+The "pants" binary takes care of managing and running the underlying
+Pants version configured in "pants.toml" in the surrounding Pants-using
+project.
+
+Once installed, if you want to update your "pants" launcher binary, use
+"SCIE_BOOT=update pants" to get the latest release or
+"SCIE_BOOT=update pants --help" to learn more options.
+
+-h | --help: Print this help message.
+
+-d | --bin-dir:
+  The directory to install the scie-pants binary in, "~/bin" by default.
+
+-b | --base-name:
+  The name to use for the scie-pants binary, "pants" by default.
+
+-V | --version:
+  The version of the scie-pants binary to install. The available
+  versions can be seen at:
+    https://github.com/pantsbuild/scie-pants/releases
+
+EOF
+}
+
+bin_dir="${HOME}/bin"
+base_name="pants"
+version="latest/download"
+while (($# > 0)); do
+  case "$1" in
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --bin-dir | -d)
+      bin_dir="$2"
+      shift
+      ;;
+    --base-name | -b)
+      base_name="$2"
+      shift
+      ;;
+    --version | -V)
+      version="download/v$2"
+      shift
+      ;;
+    *)
+      usage
+      log "Unexpected argument $1\n"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+ARCH="$(calculate_arch)"
+URL="https://github.com/pantsbuild/scie-pants/releases/${version}/scie-pants-${OS}-${ARCH}"
+dest="${bin_dir}/${base_name}"
+
+log "Downloading and installing scie-pants release ..."
+install_from_url "${URL}" "${dest}"
+log "Installed scie-pants $(PANTS_BOOTSTRAP_VERSION=report "${dest}") from ${URL} to ${dest}"
+if ! command -v "${base_name}" >/dev/null; then
+  warn "${dest} is not on the PATH."
+  log "You'll either need to invoke ${dest} explicitly or else add ${bin_dir} to your shell's PATH."
+fi
+
+log "Launching ${base_name} ..."
+"${dest}" -V

--- a/pantsup.sh
+++ b/pantsup.sh
@@ -209,10 +209,13 @@ ARCH="$(calculate_arch)"
 URL="https://github.com/pantsbuild/scie-pants/releases/${version}/scie-pants-${OS}-${ARCH}"
 dest="${bin_dir}/${base_name}"
 
-log "Downloading and installing scie-pants release ..."
+log "Downloading and installing the pants launcher ..."
 install_from_url "${URL}" "${dest}"
-green "Installed scie-pants $(PANTS_BOOTSTRAP_VERSION=report "${dest}") from ${URL} to ${dest}"
+green "Installed the pants launcher from ${URL} to ${dest}"
 if ! command -v "${base_name}" >/dev/null; then
   warn "${dest} is not on the PATH."
   log "You'll either need to invoke ${dest} explicitly or else add ${bin_dir} to your shell's PATH."
 fi
+
+green "\nRunning \`pants\` in a Pants-enabled repo will use the version of Pants configured for that repo."
+green "In a repo not yet Pants-enabled, it will prompt you to set up Pants for that repo."

--- a/tests/test_pantsup.py
+++ b/tests/test_pantsup.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Test the pantsup script."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_installs_pants(tmp_path: Path) -> None:
+    cwd = os.getcwd()
+    proc = subprocess.run(
+        ["/bin/bash", os.path.join(cwd, "pantsup.sh")],
+        env={"HOME": str(tmp_path)},
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0
+    assert b"Downloading scie-pants-" in proc.stderr
+    assert b"Verifying SHA256 of scie-pants-" in proc.stderr
+
+    bin_path = tmp_path / "bin" / "pants"
+    assert os.path.isfile(bin_path)
+    assert os.access(bin_path, os.X_OK)

--- a/tests/test_pantsup.py
+++ b/tests/test_pantsup.py
@@ -17,8 +17,8 @@ def test_installs_pants(tmp_path: Path) -> None:
     )
 
     assert proc.returncode == 0
-    assert b"Downloading scie-pants-" in proc.stderr
-    assert b"Verifying SHA256 of scie-pants-" in proc.stderr
+    assert b"Downloading and installing the pants launcher" in proc.stderr
+    assert b"Installed the pants launcher from" in proc.stderr
 
     bin_path = tmp_path / "bin" / "pants"
     assert os.path.isfile(bin_path)

--- a/tox.ini
+++ b/tox.ini
@@ -30,14 +30,14 @@ deps =
     isort
     black
 commands =
-    isort --recursive tests/ --apply
+    isort tests/ --apply
     black .
 
 [testenv:format-check]
 deps =
    {[testenv:format-run]deps}
 commands =
-    isort --recursive tests/ --check-only
+    isort tests/ --check-only
     black . --check
 
 [testenv:lint]


### PR DESCRIPTION
Once merged, you just

```
curl -sSLf https://static.pantsbuild.org/setup/pantsup.sh | sh
```

And the right scie-pants for your platform, at the latest version, gets installed to ~/bin/pants. 