### PR TITLE
get-pants.sh: Fix deletion of temp files

### DIFF
--- a/get-pants.sh
+++ b/get-pants.sh
@@ -110,7 +110,7 @@ function install_from_url() {
 
   local workdir
   workdir="$(mktemp -d)"
-  gc workdir
+  gc "${workdir}"
 
   fetch "${url}.sha256" "${workdir}"
   fetch "${url}" "${workdir}"


### PR DESCRIPTION
get-pants.sh includes a simple `gc` helper function to mark temporary files and delete them when the script exits. The script mistakenly passed it the string `workdir` rather than the value of the workdir variable. This commit changes `workdir` to `"${workdir}"`.