### PR TITLE
Install scie-pants in `~/.local/bin` instead of `~/bin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Ensure default install path is on PATH
+        # Do this here so that we can change the path before updating the init-pants action.
+        run: echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: Setup Pants
         uses: pantsbuild/actions/init-pants@v4-scie-pants
         with:

--- a/get-pants.sh
+++ b/get-pants.sh
@@ -163,7 +163,7 @@ Once installed, if you want to update your "pants" launcher binary, use
 -h | --help: Print this help message.
 
 -d | --bin-dir:
-  The directory to install the scie-pants binary in, "~/bin" by default.
+  The directory to install the scie-pants binary in, "~/.local/bin" by default.
 
 -b | --base-name:
   The name to use for the scie-pants binary, "pants" by default.
@@ -176,7 +176,7 @@ Once installed, if you want to update your "pants" launcher binary, use
 EOF
 }
 
-bin_dir="${HOME}/bin"
+bin_dir="${HOME}/.local/bin"
 base_name="pants"
 version="latest/download"
 while (($# > 0)); do

--- a/tests/test_pantsup.py
+++ b/tests/test_pantsup.py
@@ -19,7 +19,7 @@ def test_installs_pants(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert b"Downloading and installing the pants launcher" in proc.stderr
     assert b"Installed the pants launcher from" in proc.stderr
-""
+
     bin_path = tmp_path / ".local" / "bin" / "pants"
     assert os.path.isfile(bin_path)
     assert os.access(bin_path, os.X_OK)

--- a/tests/test_pantsup.py
+++ b/tests/test_pantsup.py
@@ -19,7 +19,7 @@ def test_installs_pants(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert b"Downloading and installing the pants launcher" in proc.stderr
     assert b"Installed the pants launcher from" in proc.stderr
-
-    bin_path = tmp_path / "bin" / "pants"
+""
+    bin_path = tmp_path / ".local" / "bin" / "pants"
     assert os.path.isfile(bin_path)
     assert os.access(bin_path, os.X_OK)


### PR DESCRIPTION
Using `~/bin` does not follow the [XDG based directory spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) which recommends `~/.local/bin` and does not offer an `XDG_` env var alternative similar to other paths.

I first mentioned doing this PR in
https://github.com/pantsbuild/actions/pull/21#discussion_r1185651144