### PR TITLE
Write some additional tests for get_pants.sh

### DIFF
--- a/tests/test_get_pants.py
+++ b/tests/test_get_pants.py
@@ -39,3 +39,27 @@ def test_installs_pants_when_no_args(tmp_path: Path) -> None:
     assert b"Installed the pants launcher from" in proc.stderr
 
     _check_launcher_runs(tmp_path / ".local" / "bin" / "pants")
+
+
+def test_installs_specific_version_when_version_arg(tmp_path: Path) -> None:
+    _run(home=tmp_path, args=["--version", "0.10.0"])
+    _check_launcher_runs(tmp_path / ".local" / "bin" / "pants", expected_version="0.10.0")
+
+
+def test_fails_with_error_when_incorrect_version_arg(tmp_path: Path) -> None:
+    # we've moved past 0.1.x and never did quite this many patch releases.
+    proc = _run(home=tmp_path, args=["--version", "0.1.99999"], check=False)
+    assert proc.returncode != 0
+    assert proc.stdout == b""
+    assert b"The requested URL returned error: 404" in proc.stderr
+
+
+def test_installs_to_specific_dir_when_bin_dir_arg(tmp_path: Path) -> None:
+    custom = tmp_path / "custom"
+    _run(home=tmp_path, args=["--bin-dir", str(custom)])
+    _check_launcher_runs(custom / "pants")
+
+
+def test_installs_with_base_name_when_base_name_arg(tmp_path: Path) -> None:
+    _run(home=tmp_path, args=["--base-name", "other-name"])
+    _check_launcher_runs(tmp_path / ".local" / "bin" / "other-name")


### PR DESCRIPTION
This adjusts the tests for `get_pants.sh` to cover additional features:

- installing a specific version (`--version`)
- changing the target directory (`--bin-dir`)
- changing the executable name (`--base-name`)

It also adjusts the existing test to actually execute the installed launcher, not just check its properties, which is critical for the `--version` tests.